### PR TITLE
refactor: remove deprecated defaultHttpOptions assignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,6 @@ module.exports = async (apiClientConfig) => {
     timeout,
   })
 
-  Issuer.defaultHttpOptions = {timeout}
-
   const moneyhubIssuer = await Issuer.discover(identityServiceUrl + "/oidc")
 
   const client = new moneyhubIssuer.Client(


### PR DESCRIPTION
This is deprecated & you have the correct API usage on line 50
https://github.com/moneyhub/moneyhub-api-client/blob/399418d0879570f5a2069351c4d7a3f6db117c1d/src/index.js#L50