### PR TITLE
Add update connection method MH3-8035

### DIFF
--- a/examples/connections/update-connection.js
+++ b/examples/connections/update-connection.js
@@ -1,0 +1,37 @@
+const Moneyhub = require("../../src/index")
+const config = require("../config")
+
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "connectionId", alias: "c", type: String, description: "required"},
+  {name: "expiresAt", alias: "e", type: String, description: "required"},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const {userId, connectionId, expiresAt} = commandLineArgs(optionDefinitions)
+
+if (!userId) throw new Error("userId is required")
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.updateUserConnection({userId, connectionId, expiresAt})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/readme.md
+++ b/readme.md
@@ -553,6 +553,18 @@ const syncs = await moneyhub.getSync({
 });
 ```
 
+#### `updateUserConnection`
+
+Helper method that updates a connection. Requires scope `user:update`. Currently only the consent can be updated by updating the `expiresAt` field. This field should be a valid date-time ISO string and not be more than 90 days away. This method can only be used by those clients that have bypassed consent (the `Enforce user consent` option in the Admin Portal). If successful returns a 204.
+
+```javascript
+const user = await moneyhub.updateUserConnection({
+  userId: "user-id",
+  connectionId: "connection-id",
+  expiresAt: "2022-06-26T09:43:16.318+00:00"
+  })
+```
+
 ### Data API
 
 #### `getAccounts`

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -82,6 +82,7 @@ describe("API client", () => {
         "deleteUser",
         "getConnectionSyncs",
         "getSync",
+        "updateUserConnection",
         "getCategories",
         "getStandardCategories",
         "getCategory",

--- a/src/requests/users-and-connections.js
+++ b/src/requests/users-and-connections.js
@@ -65,15 +65,25 @@ module.exports = ({config, request}) => {
       request(`${usersEndpoint}/${userId}/connections/${connectionId}/syncs`, {
         searchParams: params,
         cc: {
-          scope: "user:read"
-        }
+          scope: "user:read",
+        },
       }),
 
     getSync: async ({userId, syncId}) =>
       request(`${usersEndpoint}/${userId}/syncs/${syncId}`, {
         cc: {
-          scope: "user:read"
-        }
-      })
+          scope: "user:read",
+        },
+      }),
+
+    updateUserConnection: async ({userId, connectionId, expiresAt}) =>
+      request(`${usersEndpoint}/${userId}/connections/${connectionId}`, {
+        method: "PATCH",
+        returnStatus: true,
+        cc: {
+          scope: "user:update",
+        },
+        body: {expiresAt},
+      }),
   }
 }


### PR DESCRIPTION
### Description:

Adds a `updateUserConnection` method to the API client for the `PATCH /user/:userId/connections/:connectionId` endpoint. Currently only used to update the `expiresAt` field to renew consent on a connection.