### PR TITLE
Sync end points

### DIFF
--- a/examples/auth/get-authorize-url-for-user.js
+++ b/examples/auth/get-authorize-url-for-user.js
@@ -12,6 +12,7 @@ const optionDefinitions = [
   {name: "bankId", alias: "b", defaultValue: DEFAULT_BANK_ID, type: String},
   {name: "nonce", alias: "n", defaultValue: DEFAULT_NONCE, type: String},
   {name: "claims", alias: "c", type: String},
+  {name: "enable-async", alias: "e", type: Boolean},
 ]
 
 const usage = commandLineUsage(
@@ -23,7 +24,7 @@ const usage = commandLineUsage(
 console.log(usage)
 
 const options = commandLineArgs(optionDefinitions)
-const {userId, state, bankId, nonce} = options
+const {userId, state, bankId, nonce, "enable-async": enableAsync} = options
 
 if (!userId) throw new Error("userId is required")
 const claims = options.claims && JSON.parse(options.claims)
@@ -39,6 +40,7 @@ const start = async () => {
       bankId,
       nonce,
       claims,
+      enableAsync,
     })
     console.log(data)
 

--- a/examples/auth/get-authorize-url.js
+++ b/examples/auth/get-authorize-url.js
@@ -12,6 +12,7 @@ const optionDefinitions = [
   {name: "nonce", alias: "n", defaultValue: DEFAULT_NONCE, type: String},
   {name: "data-scopes", alias: "d", defaultValue: DEFAULT_DATA_SCOPES_USE_CASE_1, type: String},
   {name: "claims", alias: "c", type: String},
+  {name: "enable-async", alias: "e", type: Boolean},
 ]
 
 const usage = commandLineUsage(
@@ -25,7 +26,7 @@ console.log(usage)
 const options = commandLineArgs(optionDefinitions)
 
 const claims = options.claims && JSON.parse(options.claims)
-const {state, bankId, nonce, "data-scopes": dataScopes} = options
+const {state, bankId, nonce, "data-scopes": dataScopes, "enable-async": enableAsync} = options
 
 const start = async () => {
   try {
@@ -35,6 +36,7 @@ const start = async () => {
       nonce,
       scope: `openid offline_access id:${bankId} ${dataScopes}`,
       claims,
+      enableAsync,
     })
     console.log(data)
   } catch (e) {

--- a/examples/auth/get-reauth-authorize-url-for-user.js
+++ b/examples/auth/get-reauth-authorize-url-for-user.js
@@ -12,6 +12,7 @@ const optionDefinitions = [
   {name: "state", alias: "s", defaultValue: DEFAULT_STATE, type: String},
   {name: "nonce", alias: "n", defaultValue: DEFAULT_NONCE, type: String},
   {name: "claims", alias: "l", type: String},
+  {name: "enable-async", alias: "e", type: Boolean},
 ]
 
 const usage = commandLineUsage(
@@ -23,7 +24,7 @@ const usage = commandLineUsage(
 console.log(usage)
 
 const options = commandLineArgs(optionDefinitions)
-const {userId, state, connectionId, nonce} = options
+const {userId, state, connectionId, nonce, "enable-async": enableAsync} = options
 const claims = options.claims && JSON.parse(options.claims)
 
 if (!userId || !connectionId) throw new Error("UserId and connectionId needs to be provided")
@@ -38,6 +39,7 @@ const start = async () => {
       nonce,
       connectionId,
       claims,
+      enableAsync,
     })
     console.log(data)
 

--- a/examples/auth/get-refresh-authorize-url-for-user.js
+++ b/examples/auth/get-refresh-authorize-url-for-user.js
@@ -12,6 +12,7 @@ const optionDefinitions = [
   {name: "state", alias: "s", defaultValue: DEFAULT_STATE, type: String},
   {name: "nonce", alias: "n", defaultValue: DEFAULT_NONCE, type: String},
   {name: "claims", alias: "l", type: String},
+  {name: "enable-async", alias: "e", type: Boolean},
 ]
 
 const usage = commandLineUsage(
@@ -23,7 +24,7 @@ const usage = commandLineUsage(
 console.log(usage)
 
 const options = commandLineArgs(optionDefinitions)
-const {userId, state, connectionId, nonce} = options
+const {userId, state, connectionId, nonce, "enable-async": enableAsync} = options
 const claims = options.claims && JSON.parse(options.claims)
 
 if (!userId || !connectionId) throw new Error("UserId and connectionId needs to be provided")
@@ -38,6 +39,7 @@ const start = async () => {
       nonce,
       connectionId,
       claims,
+      enableAsync
     })
     console.log(data)
 

--- a/examples/user/get-connection-syncs.js
+++ b/examples/user/get-connection-syncs.js
@@ -1,0 +1,34 @@
+const Moneyhub = require("../../src/index")
+const config = require("../config")
+
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String},
+  {name: "connectionId", alias: "c", type: String},
+  {name: "limit", alias: "l", type: Number, defaultValue: 10},
+  {name: "offset", alias: "o", type: Number, defaultValue: 0},
+]
+
+const usage = commandLineUsage({
+  header: "Options",
+  optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const {limit, offset, userId, connectionId} = commandLineArgs(optionDefinitions)
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.getConnectionSyncs({userId, connectionId, params: {limit, offset}})
+    console.log(JSON.stringify(result, null, 2))
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/examples/user/get-sync.js
+++ b/examples/user/get-sync.js
@@ -1,0 +1,32 @@
+const Moneyhub = require("../../src/index")
+const config = require("../config")
+
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String},
+  {name: "syncId", alias: "s", type: String},
+]
+
+const usage = commandLineUsage({
+  header: "Options",
+  optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const {syncId, userId} = commandLineArgs(optionDefinitions)
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.getSync({userId, syncId})
+    console.log(JSON.stringify(result, null, 2))
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,8 @@ The options below can be set on the following URL generating methods:
 - `getRefreshAuthorizeUrlForCreatedUser`
 
 The `expirationDateTime` and `transactionFromDateTime` options can be set according to the [AIS Consents documentation](https://docs.moneyhubenterprise.com/docs/ais-consents)
+
+Set `enableAsync` to true if you wish to make an AIS connection that won't wait for accounts and transactions to be fetched.
 #### `getAuthorizeUrl`
 
 This method returns an authorize url for your API client. You can redirect a user to this url, after which they will be redirected back to your `redirect_uri`. 
@@ -116,6 +118,7 @@ const url = await moneyhub.getAuthorizeUrl({
   permissions: ["ReadBeneficiariesDetail"], // optional - set of extra permissions to set for auth URL
   expirationDateTime: "2022-09-01T00:00:00.000Z", // optional
   transactionFromDateTime: "2020-09-01T00:00:00.000Z", // optional,
+  enableAsync: false // optional
 })
 
 // Default claims if none are provided
@@ -148,7 +151,8 @@ const url = await moneyhub.getAuthorizeUrlForCreatedUser({
   state: "your state value", // optional
   nonce: "your nonce value", // optional
   claims: claimsObject, // optional
-  permissions: ["ReadBeneficiariesDetail"] // optional - set of extra permissions to set for auth URL
+  permissions: ["ReadBeneficiariesDetail"], // optional - set of extra permissions to set for auth URL
+  enableAsync: false // optional
 })
 
 // Scope used with the bankId provided
@@ -179,6 +183,7 @@ const url = await moneyhub.getReauthAuthorizeUrlForCreatedUser({
   state: "your state value", // optional
   nonce: "your nonce value", // optional
   claims: claimsObject, // optional
+  enableAsync: false // optional
 })
 
 // Default claims if none are provided
@@ -207,6 +212,7 @@ const url = await moneyhub.getRefreshAuthorizeUrlForCreatedUser({
   state: "your state value", // optional
   nonce: "your nonce value", // optional
   claims: claimsObject, // optional
+  enableAsync: false // optional
 })
 
 // Default claims if none are provided
@@ -518,6 +524,30 @@ const user = await moneyhub.deleteUserConnection({
   userId: "user-id",
   connectionId: "connection-id"
   })
+```
+
+#### `getConnectionSyncs`
+
+Retrieve the syncs for a given connection ID.
+```javascript
+const syncs = await moneyhub.getConnectionSyncs({
+  userId: "user-id",
+  connectionId: "connection-id",
+  params: {
+    limit: 10,
+    offset: 0
+  }
+})
+```
+
+#### `getSync`
+
+Retrieve the syncs for the given sync ID.
+```javascript
+const syncs = await moneyhub.getSync({
+  userId: "user-id",
+  syncId: "sync-id"
+})
 ```
 
 ### Data API

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -80,6 +80,8 @@ describe("API client", () => {
         "getUserConnections",
         "deleteUserConnection",
         "deleteUser",
+        "getConnectionSyncs",
+        "getSync",
         "getCategories",
         "getStandardCategories",
         "getCategory",

--- a/src/get-auth-urls.js
+++ b/src/get-auth-urls.js
@@ -36,6 +36,7 @@ module.exports = ({client, config}) => {
     nonce,
     claims = {},
     permissions,
+    enableAsync,
     expirationDateTime,
     transactionFromDateTime,
   }) => {
@@ -54,6 +55,12 @@ module.exports = ({client, config}) => {
               ...expirationDateTime && {expirationDateTime},
               ...transactionFromDateTime && {transactionFromDateTime},
             }
+          }
+        },
+        ...enableAsync && {
+          "mh:sync": {
+            "essential": true,
+            "value": {"enableAsync": true}
           }
         }
       },
@@ -136,6 +143,7 @@ module.exports = ({client, config}) => {
       permissions,
       expirationDateTime,
       transactionFromDateTime,
+      enableAsync,
     }) => {
       const scope = `id:${bankId} openid`
       const defaultClaims = {
@@ -161,6 +169,7 @@ module.exports = ({client, config}) => {
         claims: _claims,
         expirationDateTime,
         transactionFromDateTime,
+        enableAsync,
       })
       return url
     },
@@ -173,6 +182,7 @@ module.exports = ({client, config}) => {
       claims = {},
       expirationDateTime,
       transactionFromDateTime,
+      enableAsync,
     }) => {
       const scope = "openid reauth"
       const defaultClaims = {
@@ -196,6 +206,7 @@ module.exports = ({client, config}) => {
         claims: _claims,
         expirationDateTime,
         transactionFromDateTime,
+        enableAsync,
       })
       return url
     },
@@ -208,6 +219,7 @@ module.exports = ({client, config}) => {
       claims = {},
       expirationDateTime,
       transactionFromDateTime,
+      enableAsync
     }) => {
       const scope = "openid refresh"
       const defaultClaims = {
@@ -231,6 +243,7 @@ module.exports = ({client, config}) => {
         claims: _claims,
         expirationDateTime,
         transactionFromDateTime,
+        enableAsync
       })
       return url
     },

--- a/src/requests/users-and-connections.js
+++ b/src/requests/users-and-connections.js
@@ -60,5 +60,20 @@ module.exports = ({config, request}) => {
           scope: "user:delete",
         },
       }),
+
+    getConnectionSyncs: async ({userId, connectionId, params = {}}) =>
+      request(`${usersEndpoint}/${userId}/connections/${connectionId}/syncs`, {
+        searchParams: params,
+        cc: {
+          scope: "user:read"
+        }
+      }),
+
+    getSync: async ({userId, syncId}) =>
+      request(`${usersEndpoint}/${userId}/syncs/${syncId}`, {
+        cc: {
+          scope: "user:read"
+        }
+      })
   }
 }


### PR DESCRIPTION
This PR adds the following:
- Methods for getting:
  - a connection's syncs
  - a specific sync by ID
- Allowing to pass `enableAsync` into the get auth URL methods 