### PR TITLE
Add AIS consent options to auth URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,10 +89,16 @@ const moneyhub = await Moneyhub({
 Once the api client has been initialised it provides a simple promise based interface with the following methods:
 
 ### Auth API
+The options below can be set on the following URL generating methods:
+- `getAuthorizeUrl`
+- `getAuthorizeUrlForCreatedUser`
+- `getReauthAuthorizeUrlForCreatedUser`
+- `getRefreshAuthorizeUrlForCreatedUser`
 
+The `expirationDateTime` and `transactionFromDateTime` options can be set according to the [AIS Consents documentation](https://docs.moneyhubenterprise.com/docs/ais-consents)
 #### `getAuthorizeUrl`
 
-This method returns an authorize url for your API client. You can redirect a user to this url, after which they will be redirected back to your `redirect_uri`.
+This method returns an authorize url for your API client. You can redirect a user to this url, after which they will be redirected back to your `redirect_uri`. 
 
 [Financial institutions](https://docs.moneyhubenterprise.com/docs/bank-connections)
 
@@ -100,13 +106,16 @@ This method returns an authorize url for your API client. You can redirect a use
 
 [Claims](https://docs.moneyhubenterprise.com/docs/claims)
 
+
 ```javascript
 const url = await moneyhub.getAuthorizeUrl({
   scope: "openid bank-id-scope other-data-scopes",
   state: " your state value", // optional
   nonce: "your nonce value", //optional
   claims: claimsObject, // optional
-  permissions: ["ReadBeneficiariesDetail"] // optional - set of extra permissions to set for auth URL
+  permissions: ["ReadBeneficiariesDetail"], // optional - set of extra permissions to set for auth URL
+  expirationDateTime: "2022-09-01T00:00:00.000Z", // optional
+  transactionFromDateTime: "2020-09-01T00:00:00.000Z", // optional,
 })
 
 // Default claims if none are provided

--- a/src/get-auth-urls.js
+++ b/src/get-auth-urls.js
@@ -30,7 +30,15 @@ module.exports = ({client, config}) => {
     return claims
   }
 
-  const getAuthorizeUrl = ({state, scope, nonce, claims = {}, permissions}) => {
+  const getAuthorizeUrl = ({
+    state,
+    scope,
+    nonce,
+    claims = {},
+    permissions,
+    expirationDateTime,
+    transactionFromDateTime,
+  }) => {
     const defaultClaims = {
       id_token: {
         sub: {
@@ -39,6 +47,15 @@ module.exports = ({client, config}) => {
         "mh:con_id": {
           essential: true,
         },
+        ...(expirationDateTime || transactionFromDateTime) && {
+          "mh:consent": {
+            "essential": true,
+            "value": {
+              ...expirationDateTime && {expirationDateTime},
+              ...transactionFromDateTime && {transactionFromDateTime},
+            }
+          }
+        }
       },
     }
 
@@ -116,7 +133,9 @@ module.exports = ({client, config}) => {
       nonce,
       userId,
       claims = {},
-      permissions
+      permissions,
+      expirationDateTime,
+      transactionFromDateTime,
     }) => {
       const scope = `id:${bankId} openid`
       const defaultClaims = {
@@ -140,6 +159,8 @@ module.exports = ({client, config}) => {
         nonce,
         scope,
         claims: _claims,
+        expirationDateTime,
+        transactionFromDateTime,
       })
       return url
     },
@@ -150,6 +171,8 @@ module.exports = ({client, config}) => {
       state,
       nonce,
       claims = {},
+      expirationDateTime,
+      transactionFromDateTime,
     }) => {
       const scope = "openid reauth"
       const defaultClaims = {
@@ -171,6 +194,8 @@ module.exports = ({client, config}) => {
         nonce,
         scope,
         claims: _claims,
+        expirationDateTime,
+        transactionFromDateTime,
       })
       return url
     },
@@ -181,6 +206,8 @@ module.exports = ({client, config}) => {
       state,
       nonce,
       claims = {},
+      expirationDateTime,
+      transactionFromDateTime,
     }) => {
       const scope = "openid refresh"
       const defaultClaims = {
@@ -202,6 +229,8 @@ module.exports = ({client, config}) => {
         scope,
         nonce,
         claims: _claims,
+        expirationDateTime,
+        transactionFromDateTime,
       })
       return url
     },


### PR DESCRIPTION
This allows for the AIS consent options laid out [here](https://docs.moneyhubenterprise.com/docs/ais-consents) to be passed as arguments in the authorisation URL generation methods.