### PR TITLE
Add getReconsentAuthorizeUrlForCreatedUser method MH3-7764

### DIFF
--- a/examples/auth/get-reconsent-authorize-url-for-user.js
+++ b/examples/auth/get-reconsent-authorize-url-for-user.js
@@ -1,0 +1,51 @@
+const Moneyhub = require("../../src/index")
+const config = require("../config")
+
+const {DEFAULT_STATE, DEFAULT_NONCE} = require("../constants")
+
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "connectionId", alias: "c", type: String, description: "required"},
+  {name: "expiresAt", alias: "e", type: String},
+  {name: "state", alias: "s", defaultValue: DEFAULT_STATE, type: String},
+  {name: "nonce", alias: "n", defaultValue: DEFAULT_NONCE, type: String},
+  {name: "claims", alias: "l", type: String},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+const {userId, state, connectionId, nonce, expiresAt} = options
+const claims = options.claims && JSON.parse(options.claims)
+
+if (!userId || !connectionId) throw new Error("UserId and connectionId needs to be provided")
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const data = await moneyhub.getReconsentAuthorizeUrlForCreatedUser({
+      userId,
+      state,
+      nonce,
+      connectionId,
+      claims,
+      expiresAt
+    })
+    console.log(data)
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/src/__tests__/auth-urls.js
+++ b/src/__tests__/auth-urls.js
@@ -101,4 +101,26 @@ describe("Auth Urls", () => {
 
     expect(url).to.be.a("string")
   })
+
+  it("gets a reconsent url for a user", async () => {
+    const userId = config.testUserIdWithconnection
+    const connections = await moneyhub.getUserConnections({
+      userId
+    })
+    const connectionId = connections.data.length ? connections.data[0].id : undefined
+    const url = await moneyhub.getReconsentAuthorizeUrlForCreatedUser({
+      state,
+      nonce,
+      bankId,
+      userId: "some-user-id",
+      connectionId
+    })
+
+    const {request} = querystring.parse(url)
+    const payload = parseJwt(request)
+
+    expect(url).to.be.a("string")
+    expect(payload).to.have.nested.property("claims.id_token.mh:consent")
+    expect(payload).to.have.nested.property("claims.id_token.mh:con_id")
+  })
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -116,6 +116,7 @@ describe("API client", () => {
         "getRequestUri",
         "getAuthorizeUrlForCreatedUser",
         "getReauthAuthorizeUrlForCreatedUser",
+        "getReconsentAuthorizeUrlForCreatedUser",
         "getRefreshAuthorizeUrlForCreatedUser",
         "getPaymentAuthorizeUrl",
         "getReversePaymentAuthorizeUrl",

--- a/src/get-auth-urls.js
+++ b/src/get-auth-urls.js
@@ -211,6 +211,43 @@ module.exports = ({client, config}) => {
       return url
     },
 
+    getReconsentAuthorizeUrlForCreatedUser: async ({
+      userId,
+      connectionId,
+      expiresAt,
+      state,
+      nonce,
+      claims = {},
+    }) => {
+      const scope = "openid reconsent"
+      const defaultClaims = {
+        id_token: {
+          sub: {
+            essential: true,
+            value: userId,
+          },
+          "mh:con_id": {
+            essential: true,
+            value: connectionId,
+          },
+          "mh:consent": {
+            value: {
+              expirationDateTime: expiresAt
+            }
+          }
+        },
+      }
+      const _claims = R.mergeDeepRight(defaultClaims, claims)
+
+      const url = await getAuthorizeUrl({
+        state,
+        nonce,
+        scope,
+        claims: _claims,
+      })
+      return url
+    },
+
     getRefreshAuthorizeUrlForCreatedUser: async ({
       userId,
       connectionId,


### PR DESCRIPTION
Description: 

Adds a method to create a URL to redirect a user for renewing consent on a connection.