### PR TITLE
Add test data setup to tests MH3-8525

### DIFF
--- a/examples/accounts/create-account.js
+++ b/examples/accounts/create-account.js
@@ -1,0 +1,34 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "accountData", alias: "a", type: String, description: "required"},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.createAccount({userId: options.userId, account: JSON.parse(options.accountData)})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/examples/categories/create-category.js
+++ b/examples/categories/create-category.js
@@ -1,0 +1,35 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "categoryName", alias: "n", type: String, description: "required"},
+  {name: "categoryGroup", alias: "g", type: String, description: "required"},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const {userId, categoryGroup, categoryName} = commandLineArgs(optionDefinitions)
+
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.createCustomCategory({userId, category: {group: categoryGroup, name: categoryName}})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/examples/categories/get-category.js
+++ b/examples/categories/get-category.js
@@ -1,0 +1,34 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "categoryId", alias: "c", type: String},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const {userId, categoryId} = commandLineArgs(optionDefinitions)
+
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.getCategory({userId, categoryId})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/readme.md
+++ b/readme.md
@@ -1794,6 +1794,21 @@ We have a couple of examples under the `/examples` folder that can be helpful to
 
 Instructions on how to run the integration tests for the API client can be found [here](https://www.notion.so/moneyhub/Moneyhub-API-Client-Tests-Config-0bef6e3cb922425b88f0268c1a999917)
 
+### Adding Tests
+
+The tests use root level Mocha hooks to set up and teardown test data. When adding tests please consider the following:
+- The test data IDs is passed via Mocha context to the individual tests. The test data can be found in the `this.config` object
+- To access the context in tests before or after hook ensure you are declaring as regular function instead of arrow function
+- The context cannot be accessed in the `describe` functions, only in the hooks or tests themselves
+- Any new tests added should either try to use the test data setup at beginning of the run
+- If the read only test user has to be used to create data, the test itself should clear up anything created in the after hook
+- Currently the read only test user is used for getting counterparties, holdings, rental records and regular transactions
+
+### Troubleshooting tests
+
+- If any errors occurr during test setup or teardown, this should appear as happening in the "before all" or "after all" hook in `"{root}"` with the error.
+- Errors in the `before all` hook can cause errors in the `after all` hook as it won't be able to find data to clear up.
+
 ## TypeScript
 If you wish to use the client library with TypeScript, we allow you to make use of the types that are returned from our methods. Below is an example usage to get started:
 
@@ -1808,3 +1823,4 @@ const getAccounts = ({userId}) => {
 ```
 
 The default export is of the Moneyhub constructor that takes in an argument of the config. You can use `ApiClientConfig` to type that config. The client object that is returned from the constructor can then be used to make API calls. The methods are available with arguments and returns typed.
+

--- a/src/__tests__/accounts.js
+++ b/src/__tests__/accounts.js
@@ -1,19 +1,35 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Accounts", () => {
-  let manualAccountId, moneyhub
-  const {testUserId: userId, testAccountId: accountId, testPensionId: pensionId} = config
+  let accountId,
+    accountIdWithCounterparties,
+    manualAccountId,
+    moneyhub,
+    pensionId,
+    readOnlyUserId,
+    userId
 
-  before(async () => {
-    moneyhub = await Moneyhub(config)
+  before(async function() {
+    const {
+      testUserId,
+      testAccountId,
+      readOnlyPensionId,
+      readOnlyAccountIdWithCounterparties,
+      testReadOnlyUserId,
+    } = this.config
+    accountId = testAccountId
+    userId = testUserId
+    readOnlyUserId = testReadOnlyUserId
+    accountIdWithCounterparties = readOnlyAccountIdWithCounterparties
+    pensionId = readOnlyPensionId
+    moneyhub = await Moneyhub(this.config)
   })
 
   it("get accounts", async () => {
     const accounts = await moneyhub.getAccounts({userId})
-    expect(accounts.data.length).to.be.at.least(11)
+    expect(accounts.data.length).to.be.at.least(2)
     const cashAccount = accounts.data.find(a => a.type === "cash:current")
     const pension = accounts.data.find(a => a.type === "pension")
 
@@ -28,18 +44,18 @@ describe("Accounts", () => {
 
   it("get counterparties", async () => {
     const {data: counterparties} = await moneyhub.getAccountCounterparties({
-      userId,
-      accountId
+      userId: readOnlyUserId,
+      accountId: accountIdWithCounterparties
     })
-    expect(counterparties.length).to.be.greaterThan(10)
+    expect(counterparties.length).to.be.greaterThan(6)
   })
 
   it("get holdings", async () => {
     const {data: holdings} = await moneyhub.getAccountHoldings({
-      userId,
+      userId: readOnlyUserId,
       accountId: pensionId
     })
-    expect(holdings[0].items.length).to.be.greaterThan(5)
+    expect(holdings[0].items.length).to.be.greaterThan(1)
   })
 
   xit("get recurring transactions", async () => {

--- a/src/__tests__/auth-requests.js
+++ b/src/__tests__/auth-requests.js
@@ -1,13 +1,17 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Auth requests", () => {
-  let moneyhub
+  let config, moneyhub, userId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
+  })
+
+  after(async () => {
+    await moneyhub.deleteUser({userId})
   })
 
   it("creates payment auth request", async () => {
@@ -22,6 +26,7 @@ describe("Auth requests", () => {
       },
       redirectUri: config.client.redirect_uri,
     })
+    userId = data.userId
     expect(data).to.have.property("id")
     expect(data).to.have.property("status", "pending")
     expect(data).to.have.property("redirectParams")

--- a/src/__tests__/auth-urls.js
+++ b/src/__tests__/auth-urls.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 const querystring = require("querystring")
 
@@ -16,9 +15,10 @@ const parseJwt = (token) => {
 }
 
 describe("Auth Urls", () => {
-  let moneyhub
+  let config, moneyhub
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
   })
 
@@ -103,7 +103,7 @@ describe("Auth Urls", () => {
   })
 
   it("gets a reconsent url for a user", async () => {
-    const userId = config.testUserIdWithconnection
+    const userId = config.testReadOnlyUserId
     const connections = await moneyhub.getUserConnections({
       userId
     })

--- a/src/__tests__/categories.js
+++ b/src/__tests__/categories.js
@@ -1,15 +1,16 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Categories", () => {
   let moneyhub
   let categoryId
+  let config
+  let userId
 
-  const userId = config.testUserId
-
-  before(async () => {
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,12 +1,12 @@
 /* eslint-disable max-nested-callbacks */
-const {Moneyhub} = require("../")
-const config = require("../../test/test-client-config")
+const {Moneyhub} = require("..")
 const {expect} = require("chai")
 
 describe("API client", () => {
   describe("Client configuration", () => {
-    let moneyhub
-    before(async () => {
+    let config, moneyhub
+    before(async function() {
+      config = this.config
       if (config.mode !== "TEST") {
         throw new Error("These tests require example config to be set to test mode")
       }

--- a/src/__tests__/payees.js
+++ b/src/__tests__/payees.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Payees", () => {
+  let config
   let moneyhub
   let payeeId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/payments.js
+++ b/src/__tests__/payments.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Payments", () => {
+  let config
   let moneyhub
   let paymentId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/projects.js
+++ b/src/__tests__/projects.js
@@ -1,14 +1,15 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
-const userId = config.testUserId
-
 describe("Projects", () => {
+  let config
   let moneyhub
   let projectId
-  before(async () => {
+  let userId
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/regular-transactions.js
+++ b/src/__tests__/regular-transactions.js
@@ -1,13 +1,15 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe.skip("Regular transactions", () => {
+  let config
   let moneyhub
-  const userId = config.testUserId
+  let userId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/rental-records.js
+++ b/src/__tests__/rental-records.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect, assert} = require("chai")
 
 const testRentalData = {
@@ -21,12 +20,15 @@ const testRentalData = {
 }
 
 describe("Rental records", () => {
+  let config
   let moneyhub
   let seriesId
   let rentalId
-  const userId = config.testUserIdWithconnection
+  let userId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
+    userId = config.testReadOnlyUserId
     moneyhub = await Moneyhub(config)
     const {data: regularTransactions} = await moneyhub.getRegularTransactions({userId})
     seriesId = regularTransactions[0].seriesId

--- a/src/__tests__/savings-goals.js
+++ b/src/__tests__/savings-goals.js
@@ -1,18 +1,18 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("../")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Savings Goals", () => {
+  let config
   let moneyhub
   let userId
   let goalId
   let accountId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
-    const user = await moneyhub.registerUser({clientUserId: "some-random-id"})
-    userId = user.userId
+    userId = config.testUserId
     const account = await moneyhub.createAccount({userId, account: {
       accountName: "Account name",
       providerName: "Provider name",

--- a/src/__tests__/spending-goals.js
+++ b/src/__tests__/spending-goals.js
@@ -1,17 +1,17 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("../")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Spending Goals", () => {
+  let config
   let moneyhub
   let userId
   let goalId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
-    const user = await moneyhub.registerUser({clientUserId: "some-random-id"})
-    userId = user.userId
+    userId = config.testUserId
   })
 
   it("can create a spending goal", async () => {

--- a/src/__tests__/sync.js
+++ b/src/__tests__/sync.js
@@ -1,22 +1,28 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
+const OB_MOCK_ID = "1ffe704d39629a929c8e293880fb449a"
+
 describe("Sync", () => {
+  let config
   let moneyhub
   let connectionId
-  const userId = config.testUserIdWithconnection
+  let readOnlyUserId
 
-  before(async () => {
+  before(async function() {
+    config = this.config
+    readOnlyUserId = config.testReadOnlyUserId
     moneyhub = await Moneyhub(config)
   })
 
   it("sync user connection", async () => {
-    const user = await moneyhub.getUser({userId})
-    connectionId = user.connectionIds[0]
+    const user = await moneyhub.getUser({userId: readOnlyUserId})
+    connectionId = user.connectionIds.find(
+      (connectionId) => connectionId.split(":")[0] === OB_MOCK_ID
+    )
     try {
-      const result = await moneyhub.syncUserConnection({userId, connectionId})
+      const result = await moneyhub.syncUserConnection({userId: readOnlyUserId, connectionId})
       expect(result.data.status).to.equal("ok")
     } catch (error) {
       // Even if a 500 or 429 is returned we are testing that the method calls the api

--- a/src/__tests__/tax.js
+++ b/src/__tests__/tax.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
-const userId = config.testUserId
-
 describe("Tax", () => {
+  let config
   let moneyhub
-  before(async () => {
+  let userId
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/token.js
+++ b/src/__tests__/token.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 const state = "sample-state"
@@ -8,9 +7,11 @@ const nonce = "sample-nonce"
 const code = "X3MNigTlftG~AKzSQfmVmfvVWrq"
 
 describe.skip("Exchange Code For Token", () => {
+  let config
   let moneyhub
 
   before(async () => {
+    config = this.config
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/transaction-files.js
+++ b/src/__tests__/transaction-files.js
@@ -1,17 +1,18 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 const fs = require("fs")
 const path = require("path")
 
-const userId = config.testUserId
-
 describe("Transaction Files", () => {
+  let config
   let moneyhub
   let transactionId
   let fileId
-  before(async () => {
+  let userId
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
     const {data: transactions} = await moneyhub.getTransactions({
       userId,

--- a/src/__tests__/transaction-splits.js
+++ b/src/__tests__/transaction-splits.js
@@ -1,33 +1,38 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
-const {testUserId: userId, testAccountId: accountId} = config
 const R = require("ramda")
 
 describe("Transaction Splits", () => {
+  let config
   let moneyhub
   let transactionId
   let splitId
+  let accountId
+  let userId
+  let splitTestBaseInput
 
-  const splitTestBaseInput = {
-    userId,
-    splits: [
-      {
-        categoryId: "std:39577c49-350f-45a4-8ec3-48ce205585fb",
-        amount: -1500,
-        description: "Split 1"
-      },
-      {
-        categoryId: "std:7daf3d79-98dd-4c85-b3cc-6d7ffd83fce9",
-        amount: -800,
-        description: "Split 2"
-      }
-    ]
-  }
-
-  before(async () => {
+  before(async function() {
+    config = this.config
+    accountId = config.testAccountId
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
+    splitTestBaseInput = {
+      userId,
+      splits: [
+        {
+          categoryId: "std:39577c49-350f-45a4-8ec3-48ce205585fb",
+          amount: -1500,
+          description: "Split 1"
+        },
+        {
+          categoryId: "std:7daf3d79-98dd-4c85-b3cc-6d7ffd83fce9",
+          amount: -800,
+          description: "Split 2"
+        }
+      ]
+    }
+
     const transaction = {
       accountId,
       "amount": {

--- a/src/__tests__/transactions.js
+++ b/src/__tests__/transactions.js
@@ -1,14 +1,15 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("..")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
-const userId = config.testUserId
-
 describe("Transactions", () => {
+  let config
   let moneyhub
   let transactionId
-  before(async () => {
+  let userId
+  before(async function() {
+    config = this.config
+    userId = config.testUserId
     moneyhub = await Moneyhub(config)
   })
 

--- a/src/__tests__/users.js
+++ b/src/__tests__/users.js
@@ -1,12 +1,13 @@
 /* eslint-disable max-nested-callbacks */
 const {Moneyhub} = require("../")
-const config = require("../../test/test-client-config")
 const {expect} = require("chai")
 
 describe("Users", () => {
+  let config
   let moneyhub
   let userId
-  before(async () => {
+  before(async function() {
+    config = this.config
     moneyhub = await Moneyhub(config)
   })
 

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,20 @@
+const config = require("config")
+const {Moneyhub} = require("../src/index")
+
+const setupMoneyhubClient = async (config) => Moneyhub(config)
+
+const {setupTestData} = require("./setup-test-data")
+const {teardownTestData} = require("./teardown-test-data")
+
+exports.mochaHooks = async () => {
+  const moneyhub = await setupMoneyhubClient(config)
+  return {
+    async beforeAll() {
+      this.config = await setupTestData(config, moneyhub)
+    },
+    async afterAll() {
+      return await teardownTestData(this.config, moneyhub)
+    }
+  }
+
+}

--- a/test/opts/integration-ci.json
+++ b/test/opts/integration-ci.json
@@ -7,5 +7,6 @@
     "recursive": true,
     "colors": true,
     "exit": true,
-    "spec": ["src/**/__tests__/*.js"]
+    "spec": ["src/**/__tests__/*.js"],
+    "require": ["test/hooks.js"]
   }

--- a/test/opts/integration.json
+++ b/test/opts/integration.json
@@ -5,5 +5,6 @@
     "recursive": true,
     "colors": true,
     "exit": true,
-    "spec": ["src/**/__tests__/*.js"]
+    "spec": ["src/**/__tests__/*.js"],
+    "require": ["test/hooks.js"]
   }

--- a/test/setup-test-data.js
+++ b/test/setup-test-data.js
@@ -1,0 +1,36 @@
+const {account, payee, transactions} = require("./test-data")
+const {pensionAccount, currentAccount} = account
+
+const setupTestUser = async ({moneyhub}) => await moneyhub.registerUser({})
+const setupTestAccounts = async ({moneyhub, userId}) => {
+  return Promise.all([
+    moneyhub.createAccount({userId, account: currentAccount}),
+    moneyhub.createAccount({userId, account: pensionAccount})
+  ])
+}
+const setupPayee = async ({moneyhub, userId}) => await moneyhub.addPayee({
+  ...payee,
+  userId
+})
+const setupTransaction = async ({moneyhub, userId, accountId}) => {
+  const date = new Date().toISOString()
+  return moneyhub.addTransactions({
+    userId,
+    transactions: transactions.map((trx) => ({...trx, accountId, date})),
+    params: {accountId},
+  })
+}
+
+exports.setupTestData = async function(config, moneyhub) {
+  const {userId} = await setupTestUser({moneyhub})
+  const [{data: {id: accountId}}] = await setupTestAccounts({moneyhub, userId})
+  const {data: {id: payeeId}} = await setupPayee({moneyhub, userId})
+  const {data: {id: transactionId}} = await setupTransaction({moneyhub, userId, accountId})
+  return {
+    ...config,
+    testUserId: userId,
+    testAccountId: accountId,
+    testPayeeId: payeeId,
+    testTransactionId: transactionId
+  }
+}

--- a/test/teardown-test-data.js
+++ b/test/teardown-test-data.js
@@ -1,0 +1,5 @@
+const deleteTestUser = async (moneyhub, userId) => await moneyhub.deleteUser({userId})
+
+exports.teardownTestData = async function(config, moneyhub) {
+  await deleteTestUser(moneyhub, config.testUserId)
+}

--- a/test/test-client-config.js
+++ b/test/test-client-config.js
@@ -1,3 +1,0 @@
-const config = require("config")
-
-module.exports = config

--- a/test/test-data/account.js
+++ b/test/test-data/account.js
@@ -1,0 +1,14 @@
+exports.currentAccount = {
+  accountName: "Account name",
+  providerName: "Provider name",
+  type: "cash:current",
+  accountType: "personal",
+  balance: {date: "2018-08-12", amount: {value: 300023}},
+}
+exports.pensionAccount = {
+  accountName: "Pension account",
+  providerName: "Pension provider",
+  type: "pension",
+  accountType: "personal",
+  balance: {date: "2020-08-12", amount: {value: 275000}},
+}

--- a/test/test-data/index.js
+++ b/test/test-data/index.js
@@ -1,0 +1,9 @@
+const account = require("./account")
+const {payee} = require("./payee")
+const {transactions} = require("./transactions")
+
+module.exports = {
+  account,
+  payee,
+  transactions
+}

--- a/test/test-data/payee.js
+++ b/test/test-data/payee.js
@@ -1,0 +1,5 @@
+exports.payee = {
+  accountNumber: "12345678",
+  sortCode: "123546",
+  name: "Test payee",
+}

--- a/test/test-data/transactions.js
+++ b/test/test-data/transactions.js
@@ -1,0 +1,22 @@
+exports.transactions = [
+  {
+    "amount": {
+      "value": -2300
+    },
+    "categoryId": "std:4b0255f0-0309-4509-9e05-4b4e386f9b0d",
+    "categoryIdConfirmed": true,
+    "longDescription": "New transaction",
+    "shortDescription": "transaction",
+    "notes": "notes",
+    "status": "posted",
+  },
+  {
+    "amount": {
+      "value": 7800
+    },
+    "categoryId": "std:4b0255f0-0309-4509-9e05-4b4e386f9b0d",
+    "longDescription": "ASDA",
+    "notes": "notes",
+    "status": "pending",
+  }
+]


### PR DESCRIPTION
### Description

PR to add test data setup and teardown for integration tests. This change includes:

- Adds some examples for helping to set up test data
- Adds Mocha root hooks to setup data and to delete user
- Uses Mocha execution context to pass config from the root hooks to individual tests
- Config now set in the before hook of each test (as the before hook has access to the correct context)
- Some tests have been changed so they are not creating new users but re-using the created at beginning
- Some expected values have been changed to reflect the new test data that is set up