### PR TITLE
Reverse payment payer can be specified

### DIFF
--- a/examples/payments/get-reverse-payment-authorization-url.js
+++ b/examples/payments/get-reverse-payment-authorization-url.js
@@ -13,6 +13,8 @@ const optionDefinitions = [
     description: "required",
   },
   {name: "payment-id", alias: "p", type: String, description: "required"},
+  {name: "payer-id", alias: "r", type: String},
+  {name: "payer-type", alias: "t", type: String},
   {
     name: "state",
     alias: "s",
@@ -43,6 +45,8 @@ const start = async () => {
       state: options.state,
       nonce: options.nonce,
       amount: options.amount,
+      payerId: options["payer-id"],
+      payerType: options["payer-type"]
     })
 
     console.log(url)

--- a/readme.md
+++ b/readme.md
@@ -1252,6 +1252,8 @@ const url = await moneyhub.getReversePaymentAuthorizeUrl({
   amount: "reverse payment amount" // optional
   nonce: "your nonce value", // optional
   claims: claimsObject, // optional
+  payerId: "payer id that will make the payment", // optional
+  payerType: "api-payee|mh-user-account" // optional
 })
 
 // Scope used with the bankId provided

--- a/src/get-auth-urls.ts
+++ b/src/get-auth-urls.ts
@@ -1,8 +1,16 @@
-const got = require("got")
-const R = require("ramda")
+import got from "got"
+import * as R from "ramda"
+import {ApiClientConfig} from "../types/config"
+import {GetAuthUrlsMethods} from "../types/get-auth-urls"
 const filterUndefined = R.reject(R.isNil)
 
-module.exports = ({client, config}) => {
+export default ({
+  client,
+  config,
+}: {
+  client: any
+  config: ApiClientConfig
+}): GetAuthUrlsMethods => {
   const {
     identityServiceUrl,
     client: {
@@ -13,29 +21,29 @@ module.exports = ({client, config}) => {
     },
   } = config
 
-  const setPermissionsToClaims = permissions => claims => {
+  const setPermissionsToClaims = (permissions: string[]) => (claims: object) => {
     if (permissions && R.is(Array, permissions)) {
       return R.mergeDeepRight(claims, {
         id_token: {
           "mh:consent": {
             essential: true,
             value: {
-              permissions
-            }
-          }
-        }
+              permissions,
+            },
+          },
+        },
       })
     }
 
     return claims
   }
 
-  const getAuthorizeUrl = ({
+  const getAuthorizeUrl: GetAuthUrlsMethods["getAuthorizeUrl"] = ({
     state,
     scope,
     nonce,
     claims = {},
-    permissions,
+    permissions = [],
     enableAsync,
     expirationDateTime,
     transactionFromDateTime,
@@ -54,21 +62,21 @@ module.exports = ({client, config}) => {
             "value": {
               ...expirationDateTime && {expirationDateTime},
               ...transactionFromDateTime && {transactionFromDateTime},
-            }
-          }
+            },
+          },
         },
         ...enableAsync && {
           "mh:sync": {
             "essential": true,
-            "value": {"enableAsync": true}
-          }
-        }
+            "value": {"enableAsync": true},
+          },
+        },
       },
     }
 
     const _claims = R.compose(
       setPermissionsToClaims(permissions),
-      R.mergeDeepRight(defaultClaims)
+      R.mergeDeepRight(defaultClaims),
     )(claims)
 
     const authParams = filterUndefined({
@@ -90,20 +98,20 @@ module.exports = ({client, config}) => {
         },
         {
           sign: request_object_signing_alg,
-        }
+        },
       )
-      .then((request) => ({
+      .then((request: any) => ({
         ...authParams,
         request,
       }))
       .then(client.authorizationUrl.bind(client))
   }
 
-  const getAuthorizeUrlFromRequestUri = ({requestUri}) => {
+  const getAuthorizeUrlFromRequestUri: GetAuthUrlsMethods["getAuthorizeUrlFromRequestUri"] = ({requestUri}) => {
     return `${client.issuer.authorization_endpoint}?request_uri=${requestUri}`
   }
 
-  const requestObject = ({scope, state, claims, nonce}) => {
+  const requestObject: GetAuthUrlsMethods["requestObject"] = ({scope, state, claims, nonce}) => {
     const authParams = filterUndefined({
       client_id,
       scope,
@@ -119,7 +127,7 @@ module.exports = ({client, config}) => {
     return client.requestObject(authParams)
   }
 
-  const getRequestUri = async (requestObject) => {
+  const getRequestUri: GetAuthUrlsMethods["getRequestUri"] = async (requestObject) => {
     const {body} = await got.post(identityServiceUrl + "/request", {
       body: requestObject,
       headers: {
@@ -140,7 +148,7 @@ module.exports = ({client, config}) => {
       nonce,
       userId,
       claims = {},
-      permissions,
+      permissions = [],
       expirationDateTime,
       transactionFromDateTime,
       enableAsync,
@@ -159,7 +167,7 @@ module.exports = ({client, config}) => {
       }
       const _claims = R.compose(
         setPermissionsToClaims(permissions),
-        R.mergeDeepRight(defaultClaims)
+        R.mergeDeepRight(defaultClaims),
       )(claims)
 
       const url = await getAuthorizeUrl({
@@ -232,9 +240,9 @@ module.exports = ({client, config}) => {
           },
           "mh:consent": {
             value: {
-              expirationDateTime: expiresAt
-            }
-          }
+              expirationDateTime: expiresAt,
+            },
+          },
         },
       }
       const _claims = R.mergeDeepRight(defaultClaims, claims)
@@ -256,7 +264,7 @@ module.exports = ({client, config}) => {
       claims = {},
       expirationDateTime,
       transactionFromDateTime,
-      enableAsync
+      enableAsync,
     }) => {
       const scope = "openid refresh"
       const defaultClaims = {
@@ -280,7 +288,7 @@ module.exports = ({client, config}) => {
         claims: _claims,
         expirationDateTime,
         transactionFromDateTime,
-        enableAsync
+        enableAsync,
       })
       return url
     },
@@ -333,9 +341,9 @@ module.exports = ({client, config}) => {
           },
           ...userId && {
             sub: {
-              value: userId
-            }
-          }
+              value: userId,
+            },
+          },
         },
       }
 
@@ -362,6 +370,8 @@ module.exports = ({client, config}) => {
       nonce,
       amount,
       claims = {},
+      payerId,
+      payerType,
     }) => {
       if (!state) {
         console.error("State is required")
@@ -382,6 +392,8 @@ module.exports = ({client, config}) => {
           "mh:reverse_payment": {
             essential: true,
             value: {
+              payerId,
+              payerType,
               paymentId,
               amount,
             },
@@ -457,9 +469,9 @@ module.exports = ({client, config}) => {
           },
           ...userId && {
             sub: {
-              value: userId
-            }
-          }
+              value: userId,
+            },
+          },
         },
       }
 
@@ -561,7 +573,7 @@ module.exports = ({client, config}) => {
       nonce,
       userId,
       claims = {},
-      permissions,
+      permissions = [],
       expirationDateTime,
       transactionFromDateTime,
       enableAsync,
@@ -582,7 +594,7 @@ module.exports = ({client, config}) => {
 
       const _claims = R.compose(
         setPermissionsToClaims(permissions),
-        R.mergeDeepRight(defaultClaims)
+        R.mergeDeepRight(defaultClaims),
       )(claims)
 
       const authParams = filterUndefined({

--- a/types/get-auth-urls.ts
+++ b/types/get-auth-urls.ts
@@ -8,7 +8,7 @@ export interface GetAuthUrlsMethods {
     enableAsync,
     expirationDateTime,
     transactionFromDateTime,
-  }: {
+  }: Partial<{
     state: string
     scope: string
     nonce: string
@@ -17,7 +17,7 @@ export interface GetAuthUrlsMethods {
     enableAsync: boolean
     expirationDateTime: string
     transactionFromDateTime: string
-  }) => Promise<string>
+  }>) => Promise<string>
   getAuthorizeUrlFromRequestUri: ({
     requestUri,
   }: {
@@ -28,12 +28,12 @@ export interface GetAuthUrlsMethods {
     state,
     claims,
     nonce,
-  }: {
+  }: Partial<{
     scope: string
     state: string
     claims: object
     nonce: string
-    }) => Promise<string>
+    }>) => Promise<string>
   getRequestUri: (requestObject: any) => Promise<string>
   getAuthorizeUrlForCreatedUser: ({
     bankId,
@@ -45,8 +45,7 @@ export interface GetAuthUrlsMethods {
     expirationDateTime,
     transactionFromDateTime,
     enableAsync,
-  }:
-    {
+  }: Partial<{
       bankId: string
       state: string
       nonce: string
@@ -56,7 +55,7 @@ export interface GetAuthUrlsMethods {
       expirationDateTime: string
       transactionFromDateTime: string
       enableAsync: boolean
-    }) => Promise<string>
+    }>) => Promise<string>
   getReauthAuthorizeUrlForCreatedUser: ({
     userId,
     connectionId,
@@ -66,7 +65,7 @@ export interface GetAuthUrlsMethods {
     expirationDateTime,
     transactionFromDateTime,
     enableAsync,
-  }: {
+  }: Partial<{
     userId: string
     connectionId: string
     state: string
@@ -75,7 +74,7 @@ export interface GetAuthUrlsMethods {
     expirationDateTime: string
     transactionFromDateTime: string
     enableAsync: boolean
-  }) => Promise<string>
+  }>) => Promise<string>
   getRefreshAuthorizeUrlForCreatedUser: ({
     userId,
     connectionId,
@@ -85,7 +84,7 @@ export interface GetAuthUrlsMethods {
     expirationDateTime,
     transactionFromDateTime,
     enableAsync,
-  }: {
+  }: Partial<{
     userId: string
     connectionId: string
     state: string
@@ -94,7 +93,7 @@ export interface GetAuthUrlsMethods {
     expirationDateTime: string
     transactionFromDateTime: string
     enableAsync: boolean
-  }) => Promise<string>
+  }>) => Promise<string>
   getPaymentAuthorizeUrl: ({
     bankId,
     payeeId,
@@ -110,7 +109,7 @@ export interface GetAuthUrlsMethods {
     readRefundAccount,
     userId,
     claims,
-  }: {
+  }: Partial<{
     bankId: string
     payeeId: string
     payeeType: string
@@ -124,8 +123,8 @@ export interface GetAuthUrlsMethods {
     context: string
     readRefundAccount: boolean
     userId: string
-    claims: boolean
-  }) => Promise<string>
+    claims: object
+  }>) => Promise<string>
   getReversePaymentAuthorizeUrl: ({
     bankId,
     paymentId,
@@ -133,14 +132,18 @@ export interface GetAuthUrlsMethods {
     nonce,
     amount,
     claims,
-  }: {
+    payerId,
+    payerType,
+  }: Partial<{
     bankId: string
     paymentId: string
     state: string
     nonce: string
     amount: number
     claims: object
-  }) => Promise<string>
+    payerId: string | undefined
+    payerType: "api-payee" | "mh-user-account" | undefined
+  }>) => Promise<string>
   getRecurringPaymentAuthorizeUrl: ({
     bankId,
     payeeId,
@@ -159,7 +162,7 @@ export interface GetAuthUrlsMethods {
     nonce,
     userId,
     claims,
-  }: {
+  }: Partial<{
     bankId: string
     payeeId: string
     payeeType: string
@@ -177,7 +180,7 @@ export interface GetAuthUrlsMethods {
     nonce: string
     userId: string
     claims: object
-  }) => Promise<string>
+  }>) => Promise<string>
   getStandingOrderAuthorizeUrl: ({
     bankId,
     payeeId,
@@ -198,7 +201,7 @@ export interface GetAuthUrlsMethods {
     nonce,
     context,
     claims,
-  }: {
+  }: Partial<{
     bankId: string
     payeeId: string
     payeeType: string
@@ -218,5 +221,43 @@ export interface GetAuthUrlsMethods {
     nonce: string
     context: string
     claims: object
-  }) => Promise<string>
+  }>) => Promise<string>
+  getReconsentAuthorizeUrlForCreatedUser: ({
+    userId,
+    connectionId,
+    expiresAt,
+    state,
+    nonce,
+    claims,
+  }: Partial<{
+    userId: string
+    connectionId: string
+    expiresAt: string
+    state: string
+    nonce: string
+    claims: object
+  }>) => Promise<string>
+  getPushedAuthorisationRequestUrl: ({
+    bankId,
+    state,
+    nonce,
+    userId,
+    claims,
+    permissions,
+    expirationDateTime,
+    transactionFromDateTime,
+    enableAsync,
+    codeChallenge,
+  }: Partial<{
+    bankId: string
+    state: string
+    nonce: string
+    userId: string
+    claims: object
+    permissions: string[]
+    expirationDateTime: string
+    transactionFromDateTime: string
+    enableAsync: boolean
+    codeChallenge: string
+  }>) => Promise<string>
 }


### PR DESCRIPTION
- Allows for reverse payment payer to be specified when making an auth URL for a reverse payment
- get-auth-urls file updated to be typescript to allow for better typing