### PR TITLE
Remove authParams from getAuthorizeUrl

### DIFF
--- a/src/get-auth-urls.ts
+++ b/src/get-auth-urls.ts
@@ -114,7 +114,6 @@ export default ({
         },
       )
       .then((request: Awaited<ReturnType<Client["requestObject"]>>) => ({
-        ...authParams,
         request,
       }))
       .then(client.authorizationUrl.bind(client))


### PR DESCRIPTION
This PR removes the need for `authParams` to be specified in the authorisation URL generated, considering the request object holds all that information already.