### PR TITLE
Add payeeless payments and version for counterparties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+4.20.0 / 2022-09-15
+==================
+
+**Features**
+
+* Update getAccountCounterparties to include version
+* Update getPaymentAuthorizeUrl to accept a payee instead of payeeId
+* Update getRecurringPaymentAuthorizeUrl to accept a payee instead of payeeId
+* Update getStandingOrderAuthorizeUrl to accept a payee instead of payeeId
+* Update create-payement example to accept a payee instead of payeeId
+* Update create-standing-order example to accept a payee instead of payeeId
+
 4.13.0 / 2022-01-05
 ==================
 

--- a/examples/accounts/get-account-counterparties.js
+++ b/examples/accounts/get-account-counterparties.js
@@ -27,7 +27,9 @@ const start = async () => {
     const result = await moneyhub.getAccountCounterparties({
       userId: options.userId,
       accountId: options.accountId,
-      counterpartiesVersion: options.counterpartiesVersion
+      params: {
+        counterpartiesVersion: options.counterpartiesVersion
+      },
     })
     console.log(JSON.stringify(result, null, 2))
 

--- a/examples/auth-requests/create-payment.js
+++ b/examples/auth-requests/create-payment.js
@@ -1,9 +1,12 @@
 const {Moneyhub} = require("../../src/index")
+const qs = require("querystring")
 const config = require("../config")
 const {DEFAULT_BANK_ID} = require("../constants")
 
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
+
+const defaultPayee = "accountNumber=12345678&sortCode=123456&name=test"
 
 const optionDefinitions = [
   {
@@ -13,7 +16,8 @@ const optionDefinitions = [
     type: String,
     description: "required",
   },
-  {name: "payee-id", alias: "p", type: String, description: "required"},
+  {name: "payee-id", alias: "p", type: String},
+  {name: "payee", type: String},
   {name: "payee-type", type: String},
   {name: "payer-id", type: String},
   {name: "payer-type", type: String},
@@ -51,10 +55,12 @@ console.log(JSON.stringify(options, null, 2))
 const start = async () => {
   try {
     const moneyhub = await Moneyhub(config)
+    const payee = qs.parse(options.payee || defaultPayee)
     const data = await moneyhub.createAuthRequest({
       scope: `openid payment id:${options["bank-id"]}`,
       payment: {
         payeeId: options["payee-id"],
+        payee,
         amount: options.amount,
         payeeRef: options["payee-ref"],
         payerRef: options["payer-ref"],

--- a/examples/auth-requests/create-standing-order.js
+++ b/examples/auth-requests/create-standing-order.js
@@ -1,9 +1,12 @@
 const {Moneyhub} = require("../../src/index")
+const qs = require("querystring")
 const config = require("../config")
 const {DEFAULT_NONCE, DEFAULT_STATE, DEFAULT_BANK_ID} = require("../constants")
 
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
+
+const defaultPayee = "accountNumber=12345678&sortCode=123456&name=test"
 
 const optionDefinitions = [
   {
@@ -13,7 +16,8 @@ const optionDefinitions = [
     type: String,
     description: "required",
   },
-  {name: "payee-id", alias: "p", type: String, description: "required"},
+  {name: "payee-id", alias: "p", type: String},
+  {name: "payee", type: String},
   {name: "payee-type", type: String},
   {name: "payer-id", type: String},
   {name: "payer-type", type: String},
@@ -64,10 +68,12 @@ console.log(JSON.stringify(options, null, 2))
 const start = async () => {
   try {
     const moneyhub = await Moneyhub(config)
+    const payee = qs.parse(options.payee || defaultPayee)
     const data = await moneyhub.createAuthRequest({
       scope: `openid standing_orders:create id:${options["bank-id"]}`,
       standingOrder: {
         payeeId: options["payee-id"],
+        payee,
         payeeType: options["payee-type"],
         payerId: options["payer-id"],
         payerType: options["payer-type"],

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,10 @@ The major upgrade from version 4.x is that the library now caters for TypeScript
 
 ```js
 // v4.x
-const Moneyhub = require("@mft/moneyhub-api-client")
+const Moneyhub = require("@mft/moneyhub-api-client");
 
 // v5.x
-const {Moneyhub} = require("@mft/moneyhub-api-client")
+const { Moneyhub } = require("@mft/moneyhub-api-client");
 ```
 
 ### Changelog
@@ -573,8 +573,8 @@ Helper method that updates a connection. Requires scope `user:update`. Currently
 const user = await moneyhub.updateUserConnection({
   userId: "user-id",
   connectionId: "connection-id",
-  expiresAt: "2022-06-26T09:43:16.318+00:00"
-  })
+  expiresAt: "2022-06-26T09:43:16.318+00:00",
+});
 ```
 
 ### Data API
@@ -678,6 +678,9 @@ Get account counterparties for a user. This function uses the scope `accounts:re
 const account = await moneyhub.getAccountCounterparties({
   userId: "userId",
   accountId: "accountId",
+  params: {
+    counterpartiesVersion: "v3",
+  },
 });
 ```
 
@@ -1197,7 +1200,8 @@ This is a helper function that returns an authorize url to authorize a payment t
 ```javascript
 const url = await moneyhub.getPaymentAuthorizeUrl({
   bankId: "Bank id to authorise payment from", // required
-  payeeId: "Id of payee", // required
+  payeeId: "Id of payee", // required or payee
+  payee: "Details of payee to create", // required or payeeId
   payeeType: "Payee type [api-payee|mh-user-account]", // optional - defaults to api-payee
   payerId: "Id of payer", // required only if payerType is defined
   payerType: "Payer type [mh-user-account]", // required only if payerId is used
@@ -1350,7 +1354,8 @@ This is a helper function that returns an authorize url to authorize a standng o
 ```javascript
 const url = await moneyhub.getStandingOrderAuthorizeUrl({
   bankId: "Bank id to authorise payment from", // required
-  payeeId: "Id of payee", // required
+  payeeId: "Id of payee", // required or payee
+  payee: "Details of payee to create", // required or payeeId
   payeeType: "Payee type [api-payee|mh-user-account]", // optional - defaults to api-payee
   payerId: "Id of payer", // required only if payerType is defined
   payerType: "Payer type [mh-user-account]", // required only if payerId is used
@@ -1442,7 +1447,8 @@ This is a helper function that returns an authorize url to authorize a recurring
 ```javascript
 const url = await moneyhub.getRecurringPaymentAuthorizeUrl({
   bankId: "Bank id to authorise payment from",
-  payeeId: "Id of payee",
+  payeeId: "Id of payee", // required or payee
+  payee: "Details of payee to create", // required or payeeId
   payeeType: "Payee type [api-payee|mh-user-account]", // optional - defaults to api-payee
   payerId: "Id of payer", // requird only if payerType is defined
   payerType: "Payer type [mh-user-account]", // required only if payerId is used
@@ -1799,6 +1805,7 @@ Instructions on how to run the integration tests for the API client can be found
 ### Adding Tests
 
 The tests use root level Mocha hooks to set up and teardown test data. When adding tests please consider the following:
+
 - The test data IDs is passed via Mocha context to the individual tests. The test data can be found in the `this.config` object
 - To access the context in tests before or after hook ensure you are declaring as regular function instead of arrow function
 - The context cannot be accessed in the `describe` functions, only in the hooks or tests themselves
@@ -1812,17 +1819,17 @@ The tests use root level Mocha hooks to set up and teardown test data. When addi
 - Errors in the `before all` hook can cause errors in the `after all` hook as it won't be able to find data to clear up.
 
 ## TypeScript
+
 If you wish to use the client library with TypeScript, we allow you to make use of the types that are returned from our methods. Below is an example usage to get started:
 
 ```ts
-import {Moneyhub, ApiClientConfig} from "@mft/moneyhub-api-client"
-const config: ApiClientConfig = {} // your config goes here and is strongly typed
+import { Moneyhub, ApiClientConfig } from "@mft/moneyhub-api-client";
+const config: ApiClientConfig = {}; // your config goes here and is strongly typed
 
-const getAccounts = ({userId}) => {
-  const moneyhub = await Moneyhub(config)
-  const accounts = await moneyhub.getAccounts({userId})
-}
+const getAccounts = ({ userId }) => {
+  const moneyhub = await Moneyhub(config);
+  const accounts = await moneyhub.getAccounts({ userId });
+};
 ```
 
 The default export is of the Moneyhub constructor that takes in an argument of the config. You can use `ApiClientConfig` to type that config. The client object that is returned from the constructor can then be used to make API calls. The methods are available with arguments and returns typed.
-

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,10 @@ The major upgrade from version 4.x is that the library now caters for TypeScript
 
 ```js
 // v4.x
-const Moneyhub = require("@mft/moneyhub-api-client");
+const Moneyhub = require("@mft/moneyhub-api-client")
 
 // v5.x
-const { Moneyhub } = require("@mft/moneyhub-api-client");
+const {Moneyhub} = require("@mft/moneyhub-api-client")
 ```
 
 ### Changelog
@@ -573,8 +573,8 @@ Helper method that updates a connection. Requires scope `user:update`. Currently
 const user = await moneyhub.updateUserConnection({
   userId: "user-id",
   connectionId: "connection-id",
-  expiresAt: "2022-06-26T09:43:16.318+00:00",
-});
+  expiresAt: "2022-06-26T09:43:16.318+00:00"
+})
 ```
 
 ### Data API
@@ -1805,7 +1805,6 @@ Instructions on how to run the integration tests for the API client can be found
 ### Adding Tests
 
 The tests use root level Mocha hooks to set up and teardown test data. When adding tests please consider the following:
-
 - The test data IDs is passed via Mocha context to the individual tests. The test data can be found in the `this.config` object
 - To access the context in tests before or after hook ensure you are declaring as regular function instead of arrow function
 - The context cannot be accessed in the `describe` functions, only in the hooks or tests themselves
@@ -1819,17 +1818,16 @@ The tests use root level Mocha hooks to set up and teardown test data. When addi
 - Errors in the `before all` hook can cause errors in the `after all` hook as it won't be able to find data to clear up.
 
 ## TypeScript
-
 If you wish to use the client library with TypeScript, we allow you to make use of the types that are returned from our methods. Below is an example usage to get started:
 
 ```ts
-import { Moneyhub, ApiClientConfig } from "@mft/moneyhub-api-client";
-const config: ApiClientConfig = {}; // your config goes here and is strongly typed
+import {Moneyhub, ApiClientConfig} from "@mft/moneyhub-api-client"
+const config: ApiClientConfig = {} // your config goes here and is strongly typed
 
-const getAccounts = ({ userId }) => {
-  const moneyhub = await Moneyhub(config);
-  const accounts = await moneyhub.getAccounts({ userId });
-};
+const getAccounts = ({userId}) => {
+  const moneyhub = await Moneyhub(config)
+  const accounts = await moneyhub.getAccounts({ userId })
+}
 ```
 
 The default export is of the Moneyhub constructor that takes in an argument of the config. You can use `ApiClientConfig` to type that config. The client object that is returned from the constructor can then be used to make API calls. The methods are available with arguments and returns typed.

--- a/src/__tests__/accounts.ts
+++ b/src/__tests__/accounts.ts
@@ -50,6 +50,9 @@ describe("Accounts", () => {
     const {data: counterparties} = await moneyhub.getAccountCounterparties({
       userId: readOnlyUserId,
       accountId: accountIdWithCounterparties,
+      params: {
+        counterpartiesVersion: "v2",
+      },
     })
     expect(counterparties.length).to.be.greaterThan(6)
     expectTypeOf<Counterparties.Counterparty[]>(counterparties)

--- a/src/__tests__/auth-urls.ts
+++ b/src/__tests__/auth-urls.ts
@@ -105,6 +105,26 @@ describe("Auth Urls", () => {
     expect(url).to.be.a("string")
   })
 
+  it("gets a payment auth url without payeeId", async () => {
+    const payee = {
+      accountNumber: "12345678",
+      sortCode: "123456",
+      name: "Test",
+    }
+
+    const url = await moneyhub.getPaymentAuthorizeUrl({
+      bankId,
+      payee,
+      payeeRef: "ref",
+      amount: 1,
+      payerRef: "another-ref",
+      state,
+      nonce,
+    })
+
+    expect(url).to.be.a("string")
+  })
+
   it("gets a reconsent url for a user", async () => {
     const connections = await moneyhub.getUserConnections({
       userId: testReadOnlyUserId,

--- a/src/get-auth-urls.ts
+++ b/src/get-auth-urls.ts
@@ -5,6 +5,7 @@ import * as R from "ramda"
 import type {ApiClientConfig} from "./schema/config"
 import {PaymentActorType} from "./schema/payment"
 import {StandingOrderFrequency} from "./schema/standing-order"
+import {RequestPayee} from "./schema/payee"
 
 const filterUndefined = R.reject(R.isNil)
 
@@ -357,6 +358,7 @@ export default ({
       bankId,
       payeeRef,
       payeeId,
+      payee,
       payeeType,
       amount,
       payerRef,
@@ -371,11 +373,12 @@ export default ({
     }: {
       bankId: string
       payeeRef: string
-      payeeId: string
+      payeeId?: string
       payeeType?: string
       amount: number
       payerRef: string
       payerId?: string
+      payee?: RequestPayee
       payerType?: string
       state?: string
       nonce?: string
@@ -389,8 +392,8 @@ export default ({
         throw new Error("Missing parameters")
       }
 
-      if (!payeeId) {
-        console.error("PayeeId is required")
+      if (!payeeId && !payee) {
+        console.error("PayeeId or Payee are required")
         throw new Error("Missing parameters")
       }
 
@@ -407,6 +410,7 @@ export default ({
               payeeRef,
               payerRef,
               payeeId,
+              payee,
               payeeType,
               payerId,
               payerType,
@@ -507,6 +511,7 @@ export default ({
     getRecurringPaymentAuthorizeUrl: async ({
       bankId,
       payeeId,
+      payee,
       payeeType,
       payerId,
       payerType,
@@ -525,6 +530,7 @@ export default ({
     }: {
       bankId: string
       payeeId?: string
+      payee?: RequestPayee
       payeeType?: string
       payerId?: string
       payerType?: string
@@ -546,6 +552,11 @@ export default ({
         throw new Error("Missing parameters")
       }
 
+      if (!payeeId && !payee) {
+        console.error("PayeeId or Payee are required")
+        throw new Error("Missing parameters")
+      }
+
       const scope = `recurring_payment:create openid id:${bankId}`
       const defaultClaims = {
         id_token: {
@@ -556,6 +567,7 @@ export default ({
             essential: true,
             value: {
               payeeId,
+              payee,
               payeeType,
               payerId,
               payerType,
@@ -596,6 +608,7 @@ export default ({
     getStandingOrderAuthorizeUrl: async ({
       bankId,
       payeeId,
+      payee,
       payeeType,
       payerId,
       payerType,
@@ -615,7 +628,8 @@ export default ({
       claims = {},
     }: {
       bankId: string
-      payeeId: string
+      payeeId?: string
+      payee?: RequestPayee
       payeeType?: string
       payerId?: string
       payerType?: string
@@ -639,8 +653,8 @@ export default ({
         throw new Error("Missing parameters")
       }
 
-      if (!payeeId) {
-        console.error("PayeeId is required")
+      if (!payeeId && !payee) {
+        console.error("PayeeId or Payee are required")
         throw new Error("Missing parameters")
       }
 
@@ -654,6 +668,7 @@ export default ({
             essential: true,
             value: {
               payeeId,
+              payee,
               payeeType,
               payerId,
               payerType,

--- a/src/request.ts
+++ b/src/request.ts
@@ -32,6 +32,7 @@ export interface RequestsParams {
 export interface SearchParams {
   limit?: number
   offset?: number
+  counterpartiesVersion?: string
 }
 
 export interface ApiResponse<T> {

--- a/src/requests/accounts.ts
+++ b/src/requests/accounts.ts
@@ -80,8 +80,9 @@ export default ({
         },
       ),
 
-    getAccountCounterparties: async ({userId, accountId}) =>
+    getAccountCounterparties: async ({userId, accountId, params = {}}) =>
       request(`${resourceServerUrl}/accounts/${accountId}/counterparties`, {
+        searchParams: params,
         cc: {
           scope: "accounts:read transactions:read:all",
           sub: userId,

--- a/src/requests/types/accounts.ts
+++ b/src/requests/types/accounts.ts
@@ -49,6 +49,7 @@ export interface AccountsRequests {
   }: {
     userId: string
     accountId: string
+    params?: SearchParams
   }) => Promise<ApiResponse<Counterparty[]>>
   getAccountRecurringTransactions: ({
     userId,

--- a/src/schema/payee.ts
+++ b/src/schema/payee.ts
@@ -13,6 +13,12 @@ export interface Payee {
   userId?: string
 }
 
+export interface RequestPayee {
+  accountNumber: string
+  sortCode: string
+  name: string
+}
+
 export interface PayeesSearchParams extends SearchParams {
   userId?: string
   hasUserId?: boolean


### PR DESCRIPTION
MH3-9370

This change adds a version param for counterparties
This change adds the ability to replace a payeeId with payee in auth-requests.

Tests updated / added