### PR TITLE
Add routes for patch account and post account balances

### DIFF
--- a/src/__tests__/accounts.ts
+++ b/src/__tests__/accounts.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-nested-callbacks */
 import {expect} from "chai"
 import {expectTypeOf} from "expect-type"
+import {AccountBalancePost, AccountPatch} from "src/schema/account"
 
 import {Moneyhub, MoneyhubInstance, Accounts, Counterparties, Holdings, Transactions} from ".."
 
@@ -95,6 +96,33 @@ describe("Accounts", function() {
     manualAccountId = data.id
     expect(data.id).to.not.be.undefined
     expectTypeOf<Accounts.Account>(data)
+  })
+
+  it("creates a new balance", async function() {
+    const balance: AccountBalancePost = {
+      amount: {
+        value: 154700,
+      },
+      date: "2022-01-01",
+    }
+    const {data} = await moneyhub.addAccountBalance({userId, accountId: manualAccountId, balance})
+    expect(data.amount.value).to.equal(balance.amount.value)
+    expectTypeOf<Accounts.AccountBalancePost>(data)
+  })
+
+  it("updates an account", async function() {
+    const accountPatch: AccountPatch = {
+      accountName: "Updated Account Name",
+      providerName: "Updated Provider Name",
+      details: {
+        AER: 14,
+      },
+    }
+
+    const {data} = await moneyhub.updateAccount({userId, accountId: manualAccountId, account: accountPatch})
+    expect(data.accountName).equals("Updated Account Name")
+    expect(data.providerName).equals("Updated Provider Name")
+    expect(data.details.AER).to.equal(14)
   })
 
   it("deletes manual account", async function() {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -35,6 +35,8 @@ describe("API client", function() {
         "getAccountStandingOrders",
         "getAccountStandingOrdersWithDetail",
         "createAccount",
+        "addAccountBalance",
+        "updateAccount",
         "deleteAccount",
         "createAuthRequest",
         "completeAuthRequest",

--- a/src/requests/accounts.ts
+++ b/src/requests/accounts.ts
@@ -136,5 +136,25 @@ export default ({
         },
         returnStatus: true,
       }),
+
+    addAccountBalance: async ({userId, accountId, balance}) =>
+      request(`${resourceServerUrl}/accounts/${accountId}/balances`, {
+        method: "POST",
+        cc: {
+          scope: "accounts:read accounts:write:all",
+          sub: userId,
+        },
+        body: balance,
+      }),
+
+    updateAccount: async ({userId, accountId, account}) =>
+      request(`${resourceServerUrl}/accounts/${accountId}`, {
+        method: "PATCH",
+        cc: {
+          scope: "accounts:read accounts:write:all",
+          sub: userId,
+        },
+        body: account,
+      }),
   }
 }

--- a/src/requests/types/accounts.ts
+++ b/src/requests/types/accounts.ts
@@ -1,5 +1,5 @@
 import type {ApiResponse, SearchParams} from "../../request"
-import type {Account, AccountWithDetails, AccountPost} from "../../schema/account"
+import type {Account, AccountWithDetails, AccountPost, AccountBalancePost, AccountPatch} from "../../schema/account"
 import type {Balance} from "../../schema/balance"
 import type {Counterparty} from "../../schema/counterparty"
 import type {HoldingWithMatches, HoldingWithMatchesAndHistory, HoldingsValuation} from "../../schema/holding"
@@ -65,7 +65,7 @@ export interface AccountsRequests {
     userId: string
     accountId: string
   }) => Promise<ApiResponse<StandingOrder[]>>
-  createAccount: ({userId}: { userId: string, account: AccountPost }) => Promise<ApiResponse<Account>>
+  createAccount: ({userId, account}: { userId: string, account: AccountPost }) => Promise<ApiResponse<Account>>
   deleteAccount: ({userId, accountId}: { userId: string, accountId: string }) => Promise<number>
   getAccountHolding: ({
     userId,
@@ -83,4 +83,6 @@ export interface AccountsRequests {
     userId: string
     accountId: string
   }) => Promise<ApiResponse<StandingOrderWithDetail[]>>
+  addAccountBalance: ({userId, accountId, balance}: {userId: string, accountId: string, balance: AccountBalancePost}) => Promise<ApiResponse<AccountBalancePost>>
+  updateAccount: ({userId, accountId, account}: {userId: string, accountId: string, account: AccountPatch}) => Promise<ApiResponse<AccountWithDetails>>
 }

--- a/src/schema/account.ts
+++ b/src/schema/account.ts
@@ -98,11 +98,25 @@ export interface AccountWithDetails extends Account {
   details: AccountDetails
 }
 
+export type AccountWriteDetails = Omit<
+  AccountDetails,
+  "iban" | "pan">
 export interface AccountPost {
   accountName: string
   providerName: string
   type: Type
   accountType: AccountType
   balance: BalancePost
-  details?: AccountDetails
+  details?: AccountWriteDetails
 }
+
+interface AccountBalancePostAmount {
+  value: number
+}
+
+export interface AccountBalancePost {
+  amount: AccountBalancePostAmount
+  date: string
+}
+
+export type AccountPatch = Pick<AccountPost, "accountName" | "providerName" | "details">


### PR DESCRIPTION
This adds the following routes to the API client:
- `PATCH /accounts/:accountId`
- `POST /accounts/:accountId/balances`