### PR TITLE
Add getAccountsList methods MH3-10323

### DIFF
--- a/examples/accounts/get-accounts-list-with-details.js
+++ b/examples/accounts/get-accounts-list-with-details.js
@@ -1,0 +1,37 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "limit", alias: "l", type: Number, description: "optional"},
+  {name: "offset", alias: "o", type: Number, description: "optional"},
+  {name: "showTransactionData", alias: "t", type: String, defaultValue: "false", description: "optional"},
+  {name: "showPerformanceScore", alias: "p", type: String, defaultValue: "false", description: "optional"},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+    const {userId, offset, limit, showPerformanceScore, showTransactionData} = options
+    const result = await moneyhub.getAccountsListWithDetails({userId, params: {offset, limit, showPerformanceScore, showTransactionData}})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/examples/accounts/get-accounts-list.js
+++ b/examples/accounts/get-accounts-list.js
@@ -1,0 +1,37 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "limit", alias: "l", type: Number, description: "optional"},
+  {name: "offset", alias: "o", type: Number, description: "optional"},
+  {name: "showTransactionData", alias: "t", type: String, defaultValue: "false", description: "optional"},
+  {name: "showPerformanceScore", alias: "p", type: String, defaultValue: "false", description: "optional"},
+]
+
+const usage = commandLineUsage(
+  {
+    header: "Options",
+    optionList: optionDefinitions,
+  }
+)
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+    const {userId, offset, limit, showPerformanceScore, showTransactionData} = options
+    const result = await moneyhub.getAccountsList({userId, params: {offset, limit, showPerformanceScore, showTransactionData}})
+    console.log(JSON.stringify(result, null, 2))
+
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+start()

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "snyk": "^1.1041.0",
         "ts-node": "^10.8.0",
         "typescript": "^4.7.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2434,9 +2437,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -5824,9 +5827,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "keyv": {

--- a/readme.md
+++ b/readme.md
@@ -637,6 +637,30 @@ const accounts = await moneyhub.getAccountsWithDetails({
 });
 ```
 
+#### `getAccountsList`
+
+Similar to getAccounts method, however this method does not return `transactionData` and `performanceScore` by default meaning data can be retrieved more quickly. These fields can still be returned on from this method by using `showTransacionData` and `showPerformanceScore` query params. This function uses the scope `accounts:read`.
+
+```javascript
+const queryParams = { limit: 10, offset: 5 , showTransacionData: false, showPerformanceScore: true};
+const accounts = await moneyhub.getAccounts({
+  userId: "userId",
+  params: queryParams,
+});
+```
+
+#### `getAccountsListWithDetails`
+
+Similar to getAccountsWithDetails method, however this method does not return `transactionData` and `performanceScore` by default meaning data can be retrieved more quickly. These fields can still be returned on from this method by using `showTransacionData` and `showPerformanceScore` query params. This function uses the scopes `accounts:read accounts_details:read`.
+
+```javascript
+const queryParams = { limit: 10, offset: 5 };
+const accounts = await moneyhub.getAccountsWithDetails({
+  userId: "userId",
+  params: queryParams,
+});
+```
+
 #### `getAccount`
 
 Get a single account for a user by the accountId. This function uses the scope `accounts:read`.

--- a/src/__tests__/accounts.ts
+++ b/src/__tests__/accounts.ts
@@ -41,6 +41,45 @@ describe("Accounts", function() {
     expectTypeOf<Accounts.Account[]>(accounts.data)
   })
 
+  it("get accounts list", async function() {
+    const accounts = await moneyhub.getAccountsList({userId})
+    expect(accounts.data.length).to.be.at.least(2)
+    const cashAccount = accounts.data.find(a => a.type === "cash:current")
+    const pension = accounts.data.find(a => a.type === "pension")
+
+    const transactionData = accounts.data.find(a => !!a.transactionData)
+
+    expect(transactionData).to.be.undefined
+    expect(cashAccount).to.not.be.undefined
+    expect(pension).to.not.be.undefined
+    expectTypeOf<Accounts.Account[]>(accounts.data)
+  })
+
+  it("get accounts list with transactionData", async function() {
+    const accounts = await moneyhub.getAccountsList({userId, params: {showTransactionData: true}})
+    expect(accounts.data.length).to.be.at.least(2)
+    const cashAccount = accounts.data.find(a => a.type === "cash:current")
+    const pension = accounts.data.find(a => a.type === "pension")
+
+    const transactionData = accounts.data.find(a => !!a.transactionData)
+
+    expect(transactionData).to.not.be.undefined
+    expect(cashAccount).to.not.be.undefined
+    expect(pension).to.not.be.undefined
+    expectTypeOf<Accounts.Account[]>(accounts.data)
+  })
+
+  it("get accounts list with details", async function() {
+    const accounts = await moneyhub.getAccountsListWithDetails({userId})
+    expect(accounts.data.length).to.be.at.least(2)
+    const cashAccount = accounts.data.find(a => a.type === "cash:current")
+    const pension = accounts.data.find(a => a.type === "pension")
+
+    expect(cashAccount).to.not.be.undefined
+    expect(pension).to.not.be.undefined
+    expectTypeOf<Accounts.Account[]>(accounts.data)
+  })
+
   it("get account", async function() {
     const {data: account} = await moneyhub.getAccount({userId, accountId})
     expect(account.id).to.eql(accountId)

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -25,6 +25,8 @@ describe("API client", function() {
         "getAccounts",
         "getAccountsWithDetails",
         "getAccount",
+        "getAccountsList",
+        "getAccountsListWithDetails",
         "getAccountBalances",
         "getAccountWithDetails",
         "getAccountHoldings",

--- a/src/requests/accounts.ts
+++ b/src/requests/accounts.ts
@@ -26,6 +26,24 @@ export default ({
         },
       }),
 
+    getAccountsList: async ({userId, params = {}}) =>
+      request(`${resourceServerUrl}/accounts-list`, {
+        searchParams: params,
+        cc: {
+          scope: "accounts:read",
+          sub: userId,
+        },
+      }),
+
+    getAccountsListWithDetails: async ({userId, params = {}}) =>
+      request(`${resourceServerUrl}/accounts-list`, {
+        searchParams: params,
+        cc: {
+          scope: "accounts:read accounts_details:read",
+          sub: userId,
+        },
+      }),
+
     getAccount: async ({userId, accountId}) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         cc: {

--- a/src/requests/types/accounts.ts
+++ b/src/requests/types/accounts.ts
@@ -14,6 +14,13 @@ export interface AccountsRequests {
     userId: string
     params?: SearchParams
   }) => Promise<ApiResponse<AccountWithDetails[]>>
+  getAccountsList: ({userId}: { userId: string, params?: SearchParams }) => Promise<ApiResponse<Account[]>>
+  getAccountsListWithDetails: ({
+    userId,
+  }: {
+    userId: string
+    params?: SearchParams
+  }) => Promise<ApiResponse<AccountWithDetails[]>>
   getAccount: ({userId, accountId}: { userId: string, accountId: string }) => Promise<ApiResponse<Account>>
   getAccountBalances: ({
     userId,


### PR DESCRIPTION
Adds method for new /accounts-list endpoint which doesn't return transactionData and performanceScore by default.