### PR TITLE
Use simple URL for PAR

### DIFF
--- a/src/get-auth-urls.ts
+++ b/src/get-auth-urls.ts
@@ -774,9 +774,9 @@ export default ({
           sign: request_object_signing_alg,
         })
 
-      const pushedRequest = await client.pushedAuthorizationRequest({request})
+      const {request_uri: requestUri} = await client.pushedAuthorizationRequest({request})
 
-      const url = client.authorizationUrl(pushedRequest)
+      const url = getAuthorizeUrlFromRequestUri({requestUri})
 
       return url
     },


### PR DESCRIPTION
Previously the PAR URL method would create a URL with query parameters like `response_type` in the URL, and sometimes this value wouldn't match the config of the client (it would always default to `code`)

This just makes the URL have a `request_uri` query parameter.