### PR TITLE
Allow for headers or token to be passed into methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,17 @@ const moneyhub = await Moneyhub({
 })
 ```
 
+When making calls to our methods that require authentication, you can provide an extra argument at the end of these methods. This argument must be an object with these optional keys:
+
+```js
+{
+  token: "full.access.token" // if specified will be added to authorisation header of request
+  headers: {
+    Authorization: "Bearer full.access.token" // can be used to specify authorisation header or additional headers
+  }
+}
+```
+
 Once the api client has been initialised it provides a simple promise based interface with the following methods:
 
 ### Auth API

--- a/src/__tests__/accounts-with-extra-options.ts
+++ b/src/__tests__/accounts-with-extra-options.ts
@@ -1,0 +1,64 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Accounts, Moneyhub, MoneyhubInstance} from ".."
+import {expectTypeOf} from "expect-type"
+
+describe("Accounts with extra options", function() {
+  let moneyhub: MoneyhubInstance,
+    userId: string
+
+  before(async function() {
+    const {
+      testUserId,
+    } = this.config
+    userId = testUserId
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  it("errors with malformed token", async function() {
+    let error: any
+    try {
+      await moneyhub.getAccounts({userId}, {
+        token: "malformed.token",
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error.response.statusCode).to.equal(401)
+  })
+
+  it("errors with malformed headers", async function() {
+    let error: any
+    try {
+      await moneyhub.getAccounts({userId}, {
+        headers: {
+          Authorization: "malformed.header",
+        },
+      })
+    } catch (err) {
+      error = err
+    }
+    expect(error.response.statusCode).to.equal(401)
+  })
+
+  it("succeeds with given token", async function() {
+    const {access_token: token} = await moneyhub.getClientCredentialTokens({scope: "accounts:read", sub: userId})
+
+    const accounts = await moneyhub.getAccounts({userId}, {
+      token,
+    })
+    expectTypeOf<Accounts.Account[]>(accounts.data)
+  })
+
+  it("succeeds with given headers", async function() {
+    const {access_token: token} = await moneyhub.getClientCredentialTokens({scope: "accounts:read", sub: userId})
+
+    const accounts = await moneyhub.getAccounts({userId}, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expectTypeOf<Accounts.Account[]>(accounts.data)
+  })
+})

--- a/src/requests/accounts.ts
+++ b/src/requests/accounts.ts
@@ -8,75 +8,83 @@ export default ({
   const {resourceServerUrl} = config
 
   return {
-    getAccounts: async ({userId, params = {}}) =>
+    getAccounts: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/accounts`, {
         searchParams: params,
         cc: {
           scope: "accounts:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountsWithDetails: async ({userId, params = {}}) =>
+    getAccountsWithDetails: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/accounts`, {
         searchParams: params,
         cc: {
           scope: "accounts:read accounts_details:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountsList: async ({userId, params = {}}) =>
+    getAccountsList: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/accounts-list`, {
         searchParams: params,
         cc: {
           scope: "accounts:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountsListWithDetails: async ({userId, params = {}}) =>
+    getAccountsListWithDetails: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/accounts-list`, {
         searchParams: params,
         cc: {
           scope: "accounts:read accounts_details:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccount: async ({userId, accountId}) =>
+    getAccount: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         cc: {
           scope: "accounts:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountBalances: async ({userId, accountId}) =>
+    getAccountBalances: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/balances`, {
         cc: {
           scope: "accounts:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountWithDetails: async ({userId, accountId}) =>
+    getAccountWithDetails: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         cc: {
           scope: "accounts:read accounts_details:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountHoldings: async ({userId, accountId}) =>
+    getAccountHoldings: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/holdings`, {
         cc: {
           scope: "accounts:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountHoldingsWithMatches: async ({userId, accountId}) =>
+    getAccountHoldingsWithMatches: async ({userId, accountId}, options) =>
       request(
         `${resourceServerUrl}/accounts/${accountId}/holdings-with-matches`,
         {
@@ -84,10 +92,11 @@ export default ({
             scope: "accounts:read",
             sub: userId,
           },
+          options,
         },
       ),
 
-    getAccountHolding: async ({userId, accountId, holdingId}) =>
+    getAccountHolding: async ({userId, accountId, holdingId}, options) =>
       request(
         `${resourceServerUrl}/accounts/${accountId}/holdings/${holdingId}`,
         {
@@ -95,19 +104,21 @@ export default ({
             scope: "accounts:read",
             sub: userId,
           },
+          options,
         },
       ),
 
-    getAccountCounterparties: async ({userId, accountId, params = {}}) =>
+    getAccountCounterparties: async ({userId, accountId, params = {}}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/counterparties`, {
         searchParams: params,
         cc: {
           scope: "accounts:read transactions:read:all",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountRecurringTransactions: async ({userId, accountId}) =>
+    getAccountRecurringTransactions: async ({userId, accountId}, options) =>
       request(
         `${resourceServerUrl}/accounts/${accountId}/recurring-transactions`,
         {
@@ -116,26 +127,29 @@ export default ({
             scope: "accounts:read transactions:read:all",
             sub: userId,
           },
+          options,
         },
       ),
 
-    getAccountStandingOrders: async ({userId, accountId}) =>
+    getAccountStandingOrders: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/standing-orders`, {
         cc: {
           scope: "accounts:read standing_orders:read",
           sub: userId,
         },
+        options,
       }),
 
-    getAccountStandingOrdersWithDetail: async ({userId, accountId}) =>
+    getAccountStandingOrdersWithDetail: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/standing-orders`, {
         cc: {
           scope: "accounts:read standing_orders_detail:read",
           sub: userId,
         },
+        options,
       }),
 
-    createAccount: async ({userId, account}) =>
+    createAccount: async ({userId, account}, options) =>
       request(`${resourceServerUrl}/accounts`, {
         method: "POST",
         cc: {
@@ -143,9 +157,10 @@ export default ({
           sub: userId,
         },
         body: account,
+        options,
       }),
 
-    deleteAccount: async ({userId, accountId}) =>
+    deleteAccount: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         method: "DELETE",
         cc: {
@@ -153,9 +168,10 @@ export default ({
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
 
-    addAccountBalance: async ({userId, accountId, balance}) =>
+    addAccountBalance: async ({userId, accountId, balance}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}/balances`, {
         method: "POST",
         cc: {
@@ -163,9 +179,10 @@ export default ({
           sub: userId,
         },
         body: balance,
+        options,
       }),
 
-    updateAccount: async ({userId, accountId, account}) =>
+    updateAccount: async ({userId, accountId, account}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         method: "PATCH",
         cc: {
@@ -173,6 +190,7 @@ export default ({
           sub: userId,
         },
         body: account,
+        options,
       }),
   }
 }

--- a/src/requests/affordability.ts
+++ b/src/requests/affordability.ts
@@ -1,11 +1,11 @@
-import type {ApiResponse, RequestsParams, SearchParams} from "../request"
+import type {ApiResponse, ExtraOptions, RequestsParams, SearchParams} from "../request"
 import type {Affordability, AffordabilityMetadata} from "../schema/affordability"
 
 export default ({config, request}: RequestsParams) => {
   const {resourceServerUrl} = config
 
   return {
-    createAffordability: async ({userId}: {userId: string}) =>
+    createAffordability: async ({userId}: {userId: string}, options?: ExtraOptions) =>
       request<ApiResponse<Affordability>>(
         `${resourceServerUrl}/affordability`,
         {
@@ -14,10 +14,11 @@ export default ({config, request}: RequestsParams) => {
             sub: userId,
           },
           method: "POST",
+          options,
         },
       ),
 
-    getAffordability: async ({userId, id}: {userId: string, id: string}) =>
+    getAffordability: async ({userId, id}: {userId: string, id: string}, options?: ExtraOptions) =>
       request<ApiResponse<Affordability>>(
         `${resourceServerUrl}/affordability/${id}`,
         {
@@ -26,12 +27,13 @@ export default ({config, request}: RequestsParams) => {
             sub: userId,
           },
           method: "GET",
+          options,
         },
       ),
 
     getAllAffordability: async ({userId, ...query}: {
       userId: string
-    } & SearchParams) =>
+    } & SearchParams, options?: ExtraOptions) =>
       request<ApiResponse<AffordabilityMetadata[]>>(
         `${resourceServerUrl}/affordability`,
         {
@@ -41,6 +43,7 @@ export default ({config, request}: RequestsParams) => {
           },
           method: "GET",
           searchParams: query,
+          options,
         },
       ),
   }

--- a/src/requests/auth-requests.ts
+++ b/src/requests/auth-requests.ts
@@ -25,7 +25,7 @@ export default ({
       expirationDateTime,
       transactionsFromDateTime,
       sync,
-    }) =>
+    }, options) =>
       request(authRequestEndpoint, {
         method: "POST",
         cc: {
@@ -48,9 +48,10 @@ export default ({
           transactionFromDateTime: transactionsFromDateTime,
           sync,
         },
+        options,
       }),
 
-    completeAuthRequest: async ({id, authParams}) =>
+    completeAuthRequest: async ({id, authParams}, options) =>
       request(`${authRequestEndpoint}/${id}`, {
         method: "PATCH",
         cc: {
@@ -59,21 +60,24 @@ export default ({
         body: {
           authParams,
         },
+        options,
       }),
 
-    getAllAuthRequests: async (params) =>
+    getAllAuthRequests: async (params, options) =>
       request(authRequestEndpoint, {
         searchParams: params,
         cc: {
           scope: "auth_requests:read",
         },
+        options,
       }),
 
-    getAuthRequest: async ({id}) =>
+    getAuthRequest: async ({id}, options) =>
       request(`${authRequestEndpoint}/${id}`, {
         cc: {
           scope: "auth_requests:read",
         },
+        options,
       }),
   }
 }

--- a/src/requests/beneficiaries.ts
+++ b/src/requests/beneficiaries.ts
@@ -1,4 +1,4 @@
-import {RequestsParams, SearchParams} from "../request"
+import {ExtraOptions, RequestsParams, SearchParams} from "../request"
 import {BeneficiariesRequests} from "./types/beneficiaries"
 export default ({config, request}: RequestsParams): BeneficiariesRequests => {
   const {resourceServerUrl} = config
@@ -12,12 +12,13 @@ export default ({config, request}: RequestsParams): BeneficiariesRequests => {
     id: string
     userId: string
     scope: string
-  }): Promise<any> =>
+  }, options?: ExtraOptions): Promise<any> =>
     request(`${resourceServerUrl}/beneficiaries/${id}`, {
       cc: {
         sub: userId,
         scope,
       },
+      options,
     })
 
   const getAllBeneficiaries = ({
@@ -28,22 +29,23 @@ export default ({config, request}: RequestsParams): BeneficiariesRequests => {
     params: SearchParams
     userId: string
     scope: string
-  }): Promise<any> =>
+  }, options?: ExtraOptions): Promise<any> =>
     request(`${resourceServerUrl}/beneficiaries`, {
       searchParams: params,
       cc: {
         sub: userId,
         scope,
       },
+      options,
     })
   return {
-    getBeneficiary: ({id, userId}) =>
-      getOneBeneficiary({id, userId, scope: BENEFICIARIES_READ_SCOPE}),
-    getBeneficiaryWithDetail: ({id, userId}) =>
-      getOneBeneficiary({id, userId, scope: BENEFICIARIES_DETAIL_READ_SCOPE}),
-    getBeneficiaries: ({userId, params = {}}) =>
-      getAllBeneficiaries({params, userId, scope: BENEFICIARIES_READ_SCOPE}),
-    getBeneficiariesWithDetail: ({userId, params = {}}) =>
-      getAllBeneficiaries({params, userId, scope: BENEFICIARIES_DETAIL_READ_SCOPE}),
+    getBeneficiary: ({id, userId}, options) =>
+      getOneBeneficiary({id, userId, scope: BENEFICIARIES_READ_SCOPE}, options),
+    getBeneficiaryWithDetail: ({id, userId}, options) =>
+      getOneBeneficiary({id, userId, scope: BENEFICIARIES_DETAIL_READ_SCOPE}, options),
+    getBeneficiaries: ({userId, params = {}}, options) =>
+      getAllBeneficiaries({params, userId, scope: BENEFICIARIES_READ_SCOPE}, options),
+    getBeneficiariesWithDetail: ({userId, params = {}}, options) =>
+      getAllBeneficiaries({params, userId, scope: BENEFICIARIES_DETAIL_READ_SCOPE}, options),
   }
 }

--- a/src/requests/categories.ts
+++ b/src/requests/categories.ts
@@ -5,44 +5,49 @@ export default ({config, request}: RequestsParams): CategoriesRequests => {
   const {resourceServerUrl} = config
 
   return {
-    getCategories: async ({userId, params = {}}) =>
+    getCategories: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/categories`, {
         searchParams: params,
         cc: {
           scope: "categories:read",
           sub: userId,
         },
+        options,
       }),
 
-    getStandardCategories: async ({params = {}}) =>
+    getStandardCategories: async ({params = {}}, options) =>
       request(`${resourceServerUrl}/standard-categories`, {
         searchParams: params,
+        options,
       }),
 
-    getCategory: async ({userId, categoryId, params = {}}) =>
+    getCategory: async ({userId, categoryId, params = {}}, options) =>
       request(`${resourceServerUrl}/categories/${categoryId}`, {
         searchParams: params,
         cc: {
           scope: "categories:read",
           sub: userId,
         },
+        options,
       }),
 
-    getCategoryGroups: async ({userId, params = {}}) =>
+    getCategoryGroups: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/category-groups`, {
         searchParams: params,
         cc: {
           scope: "categories:read",
           sub: userId,
         },
+        options,
       }),
 
-    getStandardCategoryGroups: async ({params = {}}) =>
+    getStandardCategoryGroups: async ({params = {}}, options) =>
       request(`${resourceServerUrl}/standard-category-groups`, {
         searchParams: params,
+        options,
       }),
 
-    createCustomCategory: async ({userId, category: {group, name}}) =>
+    createCustomCategory: async ({userId, category: {group, name}}, options) =>
       request(`${resourceServerUrl}/categories`, {
         method: "POST",
         cc: {
@@ -53,6 +58,7 @@ export default ({config, request}: RequestsParams): CategoriesRequests => {
           group,
           name,
         },
+        options,
       }),
   }
 }

--- a/src/requests/payees.ts
+++ b/src/requests/payees.ts
@@ -5,28 +5,31 @@ export default ({config, request}: RequestsParams): PayeesRequests => {
   const {identityServiceUrl} = config
 
   return {
-    addPayee: async ({accountNumber, sortCode, name, externalId, userId}) =>
+    addPayee: async ({accountNumber, sortCode, name, externalId, userId}, options) =>
       request(`${identityServiceUrl}/payees`, {
         method: "POST",
         body: {accountNumber, sortCode, name, externalId, userId},
         cc: {
           scope: "payee:create",
         },
+        options,
       }),
 
-    getPayees: (params = {}) =>
+    getPayees: (params = {}, options) =>
       request(`${identityServiceUrl}/payees`, {
         searchParams: params,
         cc: {
           scope: "payee:read",
         },
+        options,
       }),
 
-    getPayee: async ({id}) =>
+    getPayee: async ({id}, options) =>
       request(`${identityServiceUrl}/payees/${id}`, {
         cc: {
           scope: "payee:read",
         },
+        options,
       }),
   }
 }

--- a/src/requests/payments.ts
+++ b/src/requests/payments.ts
@@ -1,34 +1,36 @@
-import {ApiResponse, RequestsParams} from "../request"
+import {ApiResponse, ExtraOptions, RequestsParams} from "../request"
 import {PaymentsRequests} from "./types/payments"
 import {Payment} from "../schema/payment"
 
 export default ({config, request}: RequestsParams): PaymentsRequests => {
   const {identityServiceUrl} = config
 
-  const getPayment = ({id}: {id: string}): Promise<ApiResponse<Payment>> =>
+  const getPayment = ({id}: {id: string}, options?: ExtraOptions): Promise<ApiResponse<Payment>> =>
     request(`${identityServiceUrl}/payments/${id}`, {
       cc: {
         scope: "payment:read",
       },
+      options,
     })
 
   return {
     getPayment,
-    getPayments: (params = {}) =>
+    getPayments: (params = {}, options) =>
       request(`${identityServiceUrl}/payments`, {
         searchParams: params,
         cc: {
           scope: "payment:read",
         },
+        options,
       }),
 
-    getPaymentFromIDToken: async ({idToken}) => {
+    getPaymentFromIDToken: async ({idToken}, options) => {
       try {
         const payload = JSON.parse(
           Buffer.from(idToken.split(".")[1], "base64").toString(),
         )
         const paymentId = payload["mh:payment"]
-        return getPayment({id: paymentId})
+        return getPayment({id: paymentId}, options)
       } catch (e: any) {
         throw new Error(
           "Error retrieving payment from passed in ID Token: " + e.message,

--- a/src/requests/projects.ts
+++ b/src/requests/projects.ts
@@ -5,23 +5,25 @@ export default ({config, request}: RequestsParams): ProjectsRequests => {
   const {resourceServerUrl} = config
 
   return {
-    getProjects: async ({userId, params = {}}) =>
+    getProjects: async ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/projects`, {
         searchParams: params,
         cc: {
           scope: "projects:read",
           sub: userId,
         },
+        options,
       }),
-    getProject: async ({userId, projectId}) =>
+    getProject: async ({userId, projectId}, options) =>
       request(`${resourceServerUrl}/projects/${projectId}`, {
         cc: {
           scope: "projects:read",
           sub: userId,
         },
+        options,
       }),
 
-    addProject: async ({userId, project}) =>
+    addProject: async ({userId, project}, options) =>
       request(`${resourceServerUrl}/projects`, {
         method: "POST",
         cc: {
@@ -29,9 +31,10 @@ export default ({config, request}: RequestsParams): ProjectsRequests => {
           sub: userId,
         },
         body: project,
+        options,
       }),
 
-    updateProject: async ({userId, projectId, project}) =>
+    updateProject: async ({userId, projectId, project}, options) =>
       request(`${resourceServerUrl}/projects/${projectId}`, {
         method: "PATCH",
         cc: {
@@ -39,9 +42,10 @@ export default ({config, request}: RequestsParams): ProjectsRequests => {
           sub: userId,
         },
         body: project,
+        options,
       }),
 
-    deleteProject: async ({userId, projectId}) =>
+    deleteProject: async ({userId, projectId}, options) =>
       request(`${resourceServerUrl}/projects/${projectId}`, {
         method: "DELETE",
         cc: {
@@ -49,6 +53,7 @@ export default ({config, request}: RequestsParams): ProjectsRequests => {
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
   }
 }

--- a/src/requests/recurring-payments.ts
+++ b/src/requests/recurring-payments.ts
@@ -5,36 +5,40 @@ export default ({config, request}: RequestsParams): RecurringPaymentsRequests =>
   const {identityServiceUrl} = config
 
   return {
-    getRecurringPayments: async (params = {}) =>
+    getRecurringPayments: async (params = {}, options) =>
       request(`${identityServiceUrl}/recurring-payments`, {
         searchParams: params,
         cc: {
           scope: "recurring_payment:read",
         },
+        options,
       }),
 
-    getRecurringPayment: async ({recurringPaymentId}) =>
+    getRecurringPayment: async ({recurringPaymentId}, options) =>
       request(`${identityServiceUrl}/recurring-payments/${recurringPaymentId}`, {
         cc: {
           scope: "recurring_payment:read",
         },
+        options,
       }),
 
-    makeRecurringPayment: async ({recurringPaymentId, payment}) =>
+    makeRecurringPayment: async ({recurringPaymentId, payment}, options) =>
       request(`${identityServiceUrl}/recurring-payments/${recurringPaymentId}/pay`, {
         method: "POST",
         body: payment,
         cc: {
           scope: "recurring_payment:create",
         },
+        options,
       }),
 
-    revokeRecurringPayment: async ({recurringPaymentId}) =>
+    revokeRecurringPayment: async ({recurringPaymentId}, options) =>
       request(`${identityServiceUrl}/recurring-payments/${recurringPaymentId}`, {
         method: "DELETE",
         cc: {
           scope: "recurring_payment:create",
         },
+        options,
       }),
   }
 }

--- a/src/requests/regular-transactions.ts
+++ b/src/requests/regular-transactions.ts
@@ -5,7 +5,7 @@ export default ({config, request}: RequestsParams): RegularTransactionsRequests 
   const {resourceServerUrl} = config
 
   return {
-    getRegularTransactions: async ({userId, params}) =>
+    getRegularTransactions: async ({userId, params}, options) =>
       request(
         `${resourceServerUrl}/regular-transactions`,
         {
@@ -14,6 +14,7 @@ export default ({config, request}: RequestsParams): RegularTransactionsRequests 
             scope: "accounts:read regular_transactions:read transactions:read:all",
             sub: userId,
           },
+          options,
         },
       ),
   }

--- a/src/requests/rental-records.ts
+++ b/src/requests/rental-records.ts
@@ -5,7 +5,7 @@ export default ({config, request}: RequestsParams): RentalRecordsRequests=> {
   const {resourceServerUrl} = config
 
   return {
-    getRentalRecords: async ({userId}) =>
+    getRentalRecords: async ({userId}, options) =>
       request(
         `${resourceServerUrl}/rental-records`,
         {
@@ -13,9 +13,10 @@ export default ({config, request}: RequestsParams): RentalRecordsRequests=> {
             scope: "rental_records:read",
             sub: userId,
           },
+          options,
         },
       ),
-    createRentalRecord: async ({userId, rentalData}) => {
+    createRentalRecord: async ({userId, rentalData}, options) => {
       return await request(
         `${resourceServerUrl}/rental-records`,
         {
@@ -25,10 +26,11 @@ export default ({config, request}: RequestsParams): RentalRecordsRequests=> {
             sub: userId,
           },
           body: rentalData,
+          options,
         },
       )
     },
-    deleteRentalRecord: async ({userId, rentalId}) => {
+    deleteRentalRecord: async ({userId, rentalId}, options) => {
       return await request(
         `${resourceServerUrl}/rental-records/${rentalId}`,
         {
@@ -37,6 +39,7 @@ export default ({config, request}: RequestsParams): RentalRecordsRequests=> {
             scope: "rental_records:write",
             sub: userId,
           },
+          options,
         },
       )
     },

--- a/src/requests/savings-goals.ts
+++ b/src/requests/savings-goals.ts
@@ -6,22 +6,24 @@ export default ({config, request}: RequestsParams): SavingsGoalsRequests => {
   const savingsGoalsEndpoint = resourceServerUrl + "/savings-goals"
 
   return {
-    getSavingsGoals: async (params = {}, userId) =>
+    getSavingsGoals: async (params = {}, userId, options) =>
       request(savingsGoalsEndpoint, {
         searchParams: params,
         cc: {
           scope: "savings_goals:read",
           sub: userId,
         },
+        options,
       }),
-    getSavingsGoal: async ({goalId, userId}) =>
+    getSavingsGoal: async ({goalId, userId}, options) =>
       request(`${savingsGoalsEndpoint}/${goalId}`, {
         cc: {
           scope: "savings_goals:read",
           sub: userId,
         },
+        options,
       }),
-    createSavingsGoal: async ({name, imageUrl, notes, accounts, amount, userId}) =>
+    createSavingsGoal: async ({name, imageUrl, notes, accounts, amount, userId}, options) =>
       request(savingsGoalsEndpoint, {
         method: "POST",
         cc: {
@@ -29,8 +31,9 @@ export default ({config, request}: RequestsParams): SavingsGoalsRequests => {
           sub: userId,
         },
         body: {name, imageUrl, notes, accounts, amount},
+        options,
       }),
-    updateSavingsGoal: async ({goalId, name, amount, imageUrl, notes, accounts, userId}) =>
+    updateSavingsGoal: async ({goalId, name, amount, imageUrl, notes, accounts, userId}, options) =>
       request(`${savingsGoalsEndpoint}/${goalId}`, {
         method: "PATCH",
         cc: {
@@ -38,8 +41,9 @@ export default ({config, request}: RequestsParams): SavingsGoalsRequests => {
           sub: userId,
         },
         body: {name, amount, imageUrl, notes, accounts},
+        options,
       }),
-    deleteSavingsGoal: async ({goalId, userId}) =>
+    deleteSavingsGoal: async ({goalId, userId}, options) =>
       request(`${savingsGoalsEndpoint}/${goalId}`, {
         method: "DELETE",
         cc: {
@@ -47,6 +51,7 @@ export default ({config, request}: RequestsParams): SavingsGoalsRequests => {
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
   }
 }

--- a/src/requests/spending-analysis.ts
+++ b/src/requests/spending-analysis.ts
@@ -5,7 +5,7 @@ export default ({config, request}: RequestsParams): SpendingAnalysisRequests => 
   const {resourceServerUrl} = config
 
   return {
-    getSpendingAnalysis: async ({userId, dates, accountIds, categoryIds, projectIds}) => {
+    getSpendingAnalysis: async ({userId, dates, accountIds, categoryIds, projectIds}, options) => {
       return await request(
         `${resourceServerUrl}/spending-analysis`,
         {
@@ -15,6 +15,7 @@ export default ({config, request}: RequestsParams): SpendingAnalysisRequests => 
             sub: userId,
           },
           body: {dates, accountIds, categoryIds, projectIds},
+          options,
         },
       )
     },

--- a/src/requests/spending-goals.ts
+++ b/src/requests/spending-goals.ts
@@ -6,22 +6,24 @@ export default ({config, request}: RequestsParams): SpendingGoalsRequests => {
   const spendingGoalsEndpoint = resourceServerUrl + "/spending-goals"
 
   return {
-    getSpendingGoals: async (params = {}, userId) =>
+    getSpendingGoals: async (params = {}, userId, options) =>
       request(spendingGoalsEndpoint, {
         searchParams: params,
         cc: {
           scope: "spending_goals:read",
           sub: userId,
         },
+        options,
       }),
-    getSpendingGoal: async ({goalId, userId}) =>
+    getSpendingGoal: async ({goalId, userId}, options) =>
       request(`${spendingGoalsEndpoint}/${goalId}`, {
         cc: {
           scope: "spending_goals:read",
           sub: userId,
         },
+        options,
       }),
-    createSpendingGoal: async ({categoryId, periodType, periodStart, amount, userId}) =>
+    createSpendingGoal: async ({categoryId, periodType, periodStart, amount, userId}, options) =>
       request(spendingGoalsEndpoint, {
         method: "POST",
         cc: {
@@ -29,8 +31,9 @@ export default ({config, request}: RequestsParams): SpendingGoalsRequests => {
           sub: userId,
         },
         body: {categoryId, periodType, periodStart, amount},
+        options,
       }),
-    updateSpendingGoal: async ({goalId, categoryId, amount, userId}) =>
+    updateSpendingGoal: async ({goalId, categoryId, amount, userId}, options) =>
       request(`${spendingGoalsEndpoint}/${goalId}`, {
         method: "PATCH",
         cc: {
@@ -38,8 +41,9 @@ export default ({config, request}: RequestsParams): SpendingGoalsRequests => {
           sub: userId,
         },
         body: {categoryId, amount},
+        options,
       }),
-    deleteSpendingGoal: async ({goalId, userId}) =>
+    deleteSpendingGoal: async ({goalId, userId}, options) =>
       request(`${spendingGoalsEndpoint}/${goalId}`, {
         method: "DELETE",
         cc: {
@@ -47,6 +51,7 @@ export default ({config, request}: RequestsParams): SpendingGoalsRequests => {
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
   }
 }

--- a/src/requests/standing-orders.ts
+++ b/src/requests/standing-orders.ts
@@ -1,25 +1,27 @@
-import {ApiResponse, RequestsParams} from "../request"
+import {ApiResponse, ExtraOptions, RequestsParams} from "../request"
 import {StandingOrdersRequests} from "./types/standing-orders"
 import {StandingOrderRequest} from "../schema/standing-order"
 
 export default ({config, request}: RequestsParams): StandingOrdersRequests => {
   const {identityServiceUrl} = config
 
-  const getStandingOrder = ({id}: {id: string}): Promise<ApiResponse<StandingOrderRequest>> =>
+  const getStandingOrder = ({id}: {id: string}, options?: ExtraOptions): Promise<ApiResponse<StandingOrderRequest>> =>
     request(`${identityServiceUrl}/standing-orders/${id}`, {
       cc: {
         scope: "payment:read",
       },
+      options,
     })
 
   return {
     getStandingOrder,
-    getStandingOrders: (params = {}) =>
+    getStandingOrders: (params = {}, options) =>
       request(`${identityServiceUrl}/standing-orders`, {
         searchParams: params,
         cc: {
           scope: "payment:read",
         },
+        options,
       }),
   }
 }

--- a/src/requests/sync.ts
+++ b/src/requests/sync.ts
@@ -12,7 +12,7 @@ export default ({config, request}: RequestsParams): SyncRequests => {
       connectionId,
       customerIpAddress,
       customerLastLoggedTime,
-    }) =>
+    }, options) =>
       request(`${resourceServerUrl}/sync/${connectionId}`, {
         method: "POST",
         body: filterUndefined({customerIpAddress, customerLastLoggedTime}),
@@ -20,6 +20,7 @@ export default ({config, request}: RequestsParams): SyncRequests => {
           scope: "accounts:read accounts:write:all",
           sub: userId,
         },
+        options,
       }),
   }
 }

--- a/src/requests/tax.ts
+++ b/src/requests/tax.ts
@@ -6,13 +6,14 @@ export default ({config, request}: RequestsParams): TaxRequests => {
   const {resourceServerUrl} = config
 
   return {
-    getTaxReturn: ({userId, params = {}}) =>
+    getTaxReturn: ({userId, params = {}}, options) =>
       request(`${resourceServerUrl}/tax`, {
         searchParams: R.reject(R.isNil)(params),
         cc: {
           scope: "tax:read",
           sub: userId,
         },
+        options,
       }),
   }
 }

--- a/src/requests/transaction-files.ts
+++ b/src/requests/transaction-files.ts
@@ -7,7 +7,7 @@ export default ({config, request}: RequestsParams): TransactionFilesRequests => 
   const {resourceServerUrl} = config
 
   return {
-    addFileToTransaction: async ({userId, transactionId, fileData, fileName}) => {
+    addFileToTransaction: async ({userId, transactionId, fileData, fileName}, options) => {
       const formData = new FormData()
       formData.append("file", fileData, fileName)
       return request(
@@ -19,18 +19,20 @@ export default ({config, request}: RequestsParams): TransactionFilesRequests => 
             scope: "transactions:read:all transactions:write",
             sub: userId,
           },
+          options,
         },
       )
     },
-    getTransactionFiles: async ({userId, transactionId}) =>
+    getTransactionFiles: async ({userId, transactionId}, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}/files`, {
         cc: {
           scope: "transactions:read:all transactions:write",
           sub: userId,
         },
+        options,
       }),
 
-    getTransactionFile: async ({userId, transactionId, fileId}) =>
+    getTransactionFile: async ({userId, transactionId, fileId}, options) =>
       request(
         `${resourceServerUrl}/transactions/${transactionId}/files/${fileId}`,
         {
@@ -38,10 +40,11 @@ export default ({config, request}: RequestsParams): TransactionFilesRequests => 
             scope: "transactions:read:all transactions:write",
             sub: userId,
           },
+          options,
         },
       ),
 
-    deleteTransactionFile: async ({userId, transactionId, fileId}) =>
+    deleteTransactionFile: async ({userId, transactionId, fileId}, options) =>
       request(
         `${resourceServerUrl}/transactions/${transactionId}/files/${fileId}`,
         {
@@ -51,6 +54,7 @@ export default ({config, request}: RequestsParams): TransactionFilesRequests => 
             sub: userId,
           },
           returnStatus: true,
+          options,
         },
       ),
   }

--- a/src/requests/transaction-splits.ts
+++ b/src/requests/transaction-splits.ts
@@ -8,7 +8,7 @@ export default ({config, request}: RequestsParams): TransactionSplitsRequests =>
       userId,
       transactionId,
       splits,
-    }) =>
+    }, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}/splits`, {
         method: "POST",
         cc: {
@@ -16,17 +16,19 @@ export default ({config, request}: RequestsParams): TransactionSplitsRequests =>
           sub: userId,
         },
         body: splits,
+        options,
       }),
 
     getTransactionSplits: async ({
       userId,
       transactionId,
-    }) =>
+    }, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}/splits`, {
         cc: {
           scope: "transactions:read:all",
           sub: userId,
         },
+        options,
       }),
 
     patchTransactionSplit: async ({
@@ -34,7 +36,7 @@ export default ({config, request}: RequestsParams): TransactionSplitsRequests =>
       transactionId,
       splitId,
       split,
-    }) =>
+    }, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}/splits/${splitId}`, {
         method: "PATCH",
         cc: {
@@ -42,12 +44,13 @@ export default ({config, request}: RequestsParams): TransactionSplitsRequests =>
           sub: userId,
         },
         body: split,
+        options,
       }),
 
     deleteTransactionSplits: async ({
       userId,
       transactionId,
-    }) =>
+    }, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}/splits`, {
         method: "DELETE",
         cc: {
@@ -55,6 +58,7 @@ export default ({config, request}: RequestsParams): TransactionSplitsRequests =>
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
   }
 }

--- a/src/requests/transactions.ts
+++ b/src/requests/transactions.ts
@@ -5,22 +5,24 @@ export default ({config, request}: RequestsParams): TransactionsRequests => {
   const {resourceServerUrl} = config
 
   return {
-    getTransactions: ({userId, params}) =>
+    getTransactions: ({userId, params}, options) =>
       request(`${resourceServerUrl}/transactions`, {
         searchParams: params,
         cc: {
           scope: "transactions:read:all",
           sub: userId,
         },
+        options,
       }),
-    getTransaction: ({userId, transactionId}) =>
+    getTransaction: ({userId, transactionId}, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}`, {
         cc: {
           scope: "transactions:read:all",
           sub: userId,
         },
+        options,
       }),
-    addTransaction: ({userId, transaction}) =>
+    addTransaction: ({userId, transaction}, options) =>
       request(`${resourceServerUrl}/transactions`, {
         method: "POST",
         cc: {
@@ -28,8 +30,9 @@ export default ({config, request}: RequestsParams): TransactionsRequests => {
           sub: userId,
         },
         body: transaction,
+        options,
       }),
-    addTransactions: ({userId, transactions, params = {}}) =>
+    addTransactions: ({userId, transactions, params = {}}, options) =>
       request(`${resourceServerUrl}/transactions-collection`, {
         method: "POST",
         searchParams: params,
@@ -38,8 +41,9 @@ export default ({config, request}: RequestsParams): TransactionsRequests => {
           sub: userId,
         },
         body: transactions,
+        options,
       }),
-    updateTransaction: ({userId, transactionId, transaction}) =>
+    updateTransaction: ({userId, transactionId, transaction}, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}`, {
         method: "PATCH",
         cc: {
@@ -47,8 +51,9 @@ export default ({config, request}: RequestsParams): TransactionsRequests => {
           sub: userId,
         },
         body: transaction,
+        options,
       }),
-    deleteTransaction: ({userId, transactionId}) =>
+    deleteTransaction: ({userId, transactionId}, options) =>
       request(`${resourceServerUrl}/transactions/${transactionId}`, {
         method: "DELETE",
         cc: {
@@ -56,6 +61,7 @@ export default ({config, request}: RequestsParams): TransactionsRequests => {
           sub: userId,
         },
         returnStatus: true,
+        options,
       }),
   }
 }

--- a/src/requests/types/accounts.ts
+++ b/src/requests/types/accounts.ts
@@ -1,4 +1,4 @@
-import type {ApiResponse, SearchParams} from "../../request"
+import type {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import type {Account, AccountWithDetails, AccountPost, AccountBalancePost, AccountPatch} from "../../schema/account"
 import type {Balance} from "../../schema/balance"
 import type {Counterparty} from "../../schema/counterparty"
@@ -7,49 +7,49 @@ import type {RecurringTransactionEstimate} from "../../schema/transaction"
 import type {StandingOrder, StandingOrderWithDetail} from "../../schema/standing-order"
 
 export interface AccountsRequests {
-  getAccounts: ({userId}: { userId: string, params?: SearchParams }) => Promise<ApiResponse<Account[]>>
+  getAccounts: ({userId, params}: { userId: string, params?: SearchParams }, options?: ExtraOptions) => Promise<ApiResponse<Account[]>>
   getAccountsWithDetails: ({
     userId,
   }: {
     userId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<AccountWithDetails[]>>
-  getAccountsList: ({userId}: { userId: string, params?: SearchParams }) => Promise<ApiResponse<Account[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<AccountWithDetails[]>>
+  getAccountsList: ({userId, params}: { userId: string, params?: SearchParams }, options?: ExtraOptions) => Promise<ApiResponse<Account[]>>
   getAccountsListWithDetails: ({
     userId,
   }: {
     userId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<AccountWithDetails[]>>
-  getAccount: ({userId, accountId}: { userId: string, accountId: string }) => Promise<ApiResponse<Account>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<AccountWithDetails[]>>
+  getAccount: ({userId, accountId}: { userId: string, accountId: string }, options?: ExtraOptions) => Promise<ApiResponse<Account>>
   getAccountBalances: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<Balance[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Balance[]>>
   getAccountWithDetails: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<AccountWithDetails>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<AccountWithDetails>>
   getAccountHoldings: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<HoldingsValuation[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<HoldingsValuation[]>>
   getAccountHoldingsWithMatches: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<HoldingWithMatches[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<HoldingWithMatches[]>>
   getAccountCounterparties: ({
     userId,
     accountId,
@@ -57,23 +57,23 @@ export interface AccountsRequests {
     userId: string
     accountId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<Counterparty[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Counterparty[]>>
   getAccountRecurringTransactions: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<RecurringTransactionEstimate[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RecurringTransactionEstimate[]>>
   getAccountStandingOrders: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<StandingOrder[]>>
-  createAccount: ({userId, account}: { userId: string, account: AccountPost }) => Promise<ApiResponse<Account>>
-  deleteAccount: ({userId, accountId}: { userId: string, accountId: string }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<ApiResponse<StandingOrder[]>>
+  createAccount: ({userId, account}: { userId: string, account: AccountPost }, options?: ExtraOptions) => Promise<ApiResponse<Account>>
+  deleteAccount: ({userId, accountId}: { userId: string, accountId: string }, options?: ExtraOptions) => Promise<number>
   getAccountHolding: ({
     userId,
     accountId,
@@ -82,14 +82,14 @@ export interface AccountsRequests {
     userId: string
     accountId: string
     holdingId: string
-  }) => Promise<ApiResponse<HoldingWithMatchesAndHistory>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<HoldingWithMatchesAndHistory>>
   getAccountStandingOrdersWithDetail: ({
     userId,
     accountId,
   }: {
     userId: string
     accountId: string
-  }) => Promise<ApiResponse<StandingOrderWithDetail[]>>
-  addAccountBalance: ({userId, accountId, balance}: {userId: string, accountId: string, balance: AccountBalancePost}) => Promise<ApiResponse<AccountBalancePost>>
-  updateAccount: ({userId, accountId, account}: {userId: string, accountId: string, account: AccountPatch}) => Promise<ApiResponse<AccountWithDetails>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<StandingOrderWithDetail[]>>
+  addAccountBalance: ({userId, accountId, balance}: {userId: string, accountId: string, balance: AccountBalancePost}, options?: ExtraOptions) => Promise<ApiResponse<AccountBalancePost>>
+  updateAccount: ({userId, accountId, account}: {userId: string, accountId: string, account: AccountPatch}, options?: ExtraOptions) => Promise<ApiResponse<AccountWithDetails>>
 }

--- a/src/requests/types/auth-requests.ts
+++ b/src/requests/types/auth-requests.ts
@@ -2,7 +2,7 @@ import type {AccountType} from "../../schema/account"
 import type {AuthRequestPostPayment, AuthRequestPostRecurringPayment, AuthRequestPostReversePayment} from "../../schema/payment"
 import type {AuthRequestStandingOrderPost} from "../../schema/standing-order"
 import type {AuthParams, AuthRequest} from "../../schema/auth-request"
-import type {ApiResponse, SearchParams} from "../../request"
+import type {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 
 type AuthRequestPermissions =
   | "ReadStandingOrdersBasic"
@@ -46,7 +46,7 @@ export interface AuthRequestsRequests {
     expirationDateTime,
     transactionsFromDateTime,
     sync,
-  }: CreateAuthRequestParams) => Promise<ApiResponse<AuthRequest>>
+  }: CreateAuthRequestParams, options?: ExtraOptions) => Promise<ApiResponse<AuthRequest>>
 
   completeAuthRequest: ({
     id,
@@ -54,9 +54,9 @@ export interface AuthRequestsRequests {
   }: {
     id: string
     authParams: AuthParams
-  }) => Promise<ApiResponse<AuthRequest>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<AuthRequest>>
 
-  getAllAuthRequests: (params?: SearchParams) => Promise<ApiResponse<AuthRequest[]>>
+  getAllAuthRequests: (params?: SearchParams, options?: ExtraOptions) => Promise<ApiResponse<AuthRequest[]>>
 
-  getAuthRequest: ({id}: {id: string}) => Promise<ApiResponse<AuthRequest>>
+  getAuthRequest: ({id}: {id: string}, options?: ExtraOptions) => Promise<ApiResponse<AuthRequest>>
 }

--- a/src/requests/types/beneficiaries.ts
+++ b/src/requests/types/beneficiaries.ts
@@ -1,4 +1,4 @@
-import {ApiResponse, SearchParams} from "../../request"
+import {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import {Beneficiary, BeneficiaryWithDetails} from "../../schema/beneficiary"
 
 export interface BeneficiariesRequests {
@@ -8,7 +8,7 @@ export interface BeneficiariesRequests {
   }: {
     id: string
     userId: string
-  }) => Promise<ApiResponse<Beneficiary>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Beneficiary>>
 
   getBeneficiaryWithDetail: ({
     id,
@@ -16,7 +16,7 @@ export interface BeneficiariesRequests {
   }: {
     id: string
     userId: string
-  }) => Promise<ApiResponse<BeneficiaryWithDetails>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<BeneficiaryWithDetails>>
 
   getBeneficiaries: ({
     params,
@@ -24,7 +24,7 @@ export interface BeneficiariesRequests {
   }: {
     params?: SearchParams
     userId: string
-  }) => Promise<ApiResponse<Beneficiary[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Beneficiary[]>>
 
   getBeneficiariesWithDetail: ({
     params,
@@ -32,5 +32,5 @@ export interface BeneficiariesRequests {
   }: {
     params?: SearchParams
     userId: string
-  }) => Promise<ApiResponse<BeneficiaryWithDetails[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<BeneficiaryWithDetails[]>>
 }

--- a/src/requests/types/categories.ts
+++ b/src/requests/types/categories.ts
@@ -1,4 +1,4 @@
-import {ApiResponse, SearchParams} from "../../request"
+import {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import {Category, CategoryGroup, CategoryPost, CategoryType} from "../../schema/category"
 
 export interface CategoriesRequests {
@@ -8,13 +8,13 @@ export interface CategoriesRequests {
   }: {
     userId: string
     params?: SearchParams & {type?: CategoryType}
-  }) => Promise<ApiResponse<Category[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Category[]>>
 
   getStandardCategories: ({
     params,
   }: {
     params?: SearchParams & {type?: CategoryType}
-  }) => Promise<ApiResponse<Category[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Category[]>>
 
   getCategory: ({
     userId,
@@ -24,7 +24,7 @@ export interface CategoriesRequests {
     userId: string
     categoryId: string
     params?: {type?: CategoryType}
-  }) => Promise<ApiResponse<Category>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Category>>
 
   getCategoryGroups: ({
     userId,
@@ -32,13 +32,13 @@ export interface CategoriesRequests {
   }: {
     userId: string
     params?: {type?: CategoryType}
-  }) => Promise<ApiResponse<CategoryGroup[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<CategoryGroup[]>>
 
   getStandardCategoryGroups: ({
     params,
   }: {
     params?: {type?: CategoryType}
-  }) => Promise<ApiResponse<CategoryGroup[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<CategoryGroup[]>>
 
   createCustomCategory: ({
     userId,
@@ -46,5 +46,5 @@ export interface CategoriesRequests {
   }: {
     userId: string
     category: CategoryPost
-  }) => Promise<ApiResponse<Category>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Category>>
 }

--- a/src/requests/types/payees.ts
+++ b/src/requests/types/payees.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {Payee, PayeesSearchParams} from "../../schema/payee"
 
 export interface PayeesRequests {
@@ -14,9 +14,9 @@ export interface PayeesRequests {
     name: string
     externalId?: string
     userId?: string
-  }) => Promise<ApiResponse<Payee>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Payee>>
 
-  getPayees: (params?: PayeesSearchParams) => Promise<ApiResponse<Payee[]>>
+  getPayees: (params?: PayeesSearchParams, options?: ExtraOptions) => Promise<ApiResponse<Payee[]>>
 
-  getPayee: ({id}: {id: string}) => Promise<ApiResponse<Payee>>
+  getPayee: ({id}: {id: string}, options?: ExtraOptions) => Promise<ApiResponse<Payee>>
 }

--- a/src/requests/types/payments.ts
+++ b/src/requests/types/payments.ts
@@ -1,8 +1,8 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {Payment, PaymentSearchParams} from "../../schema/payment"
 
 export interface PaymentsRequests {
-  getPayment: ({id}: {id: string}) => Promise<ApiResponse<Payment>>
-  getPayments: (params?: PaymentSearchParams) => Promise<ApiResponse<Payment[]>>
-  getPaymentFromIDToken: ({idToken}: {idToken: string}) => Promise<ApiResponse<Payment>>
+  getPayment: ({id}: {id: string}, options?: ExtraOptions) => Promise<ApiResponse<Payment>>
+  getPayments: (params?: PaymentSearchParams, options?: ExtraOptions) => Promise<ApiResponse<Payment[]>>
+  getPaymentFromIDToken: ({idToken}: {idToken: string}, options?: ExtraOptions) => Promise<ApiResponse<Payment>>
 }

--- a/src/requests/types/projects.ts
+++ b/src/requests/types/projects.ts
@@ -1,4 +1,4 @@
-import {ApiResponse, SearchParams} from "../../request"
+import {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import {Project, ProjectPatch, ProjectPost} from "../../schema/project"
 
 export interface ProjectsRequests {
@@ -8,7 +8,7 @@ export interface ProjectsRequests {
   }: {
     userId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<Project[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Project[]>>
 
   getProject: ({
     userId,
@@ -16,7 +16,7 @@ export interface ProjectsRequests {
   }: {
     userId: string
     projectId: string
-  }) => Promise<ApiResponse<Project>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Project>>
 
   addProject: ({
     userId,
@@ -24,7 +24,7 @@ export interface ProjectsRequests {
   }: {
     userId: string
     project: ProjectPost
-  }) => Promise<ApiResponse<Project>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Project>>
 
   updateProject: ({
     userId,
@@ -34,7 +34,7 @@ export interface ProjectsRequests {
     userId: string
     projectId: string
     project: ProjectPatch
-  }) => Promise<ApiResponse<Project>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Project>>
 
   deleteProject: ({
     userId,
@@ -42,5 +42,5 @@ export interface ProjectsRequests {
   }: {
     userId: string
     projectId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/recurring-payments.ts
+++ b/src/requests/types/recurring-payments.ts
@@ -1,14 +1,14 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {PaymentsClaims, RecurringPaymentRequest, RecurringPaymentSearchParams} from "../../schema/payment"
 
 export interface RecurringPaymentsRequests {
-  getRecurringPayments: (params?: RecurringPaymentSearchParams) => Promise<ApiResponse<RecurringPaymentRequest[]>>
+  getRecurringPayments: (params?: RecurringPaymentSearchParams, options?: ExtraOptions) => Promise<ApiResponse<RecurringPaymentRequest[]>>
 
   getRecurringPayment: ({
     recurringPaymentId,
   }: {
     recurringPaymentId: string
-  }) => Promise<ApiResponse<RecurringPaymentRequest>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RecurringPaymentRequest>>
 
   makeRecurringPayment: ({
     recurringPaymentId,
@@ -16,11 +16,11 @@ export interface RecurringPaymentsRequests {
   }: {
     recurringPaymentId: string
     payment: PaymentsClaims
-  }) => Promise<ApiResponse<RecurringPaymentRequest>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RecurringPaymentRequest>>
 
   revokeRecurringPayment: ({
     recurringPaymentId,
   }: {
     recurringPaymentId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/regular-transactions.ts
+++ b/src/requests/types/regular-transactions.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {RegularTransaction, RegularTransactionSearchParams} from "../../schema/regular-transaction"
 
 export interface RegularTransactionsRequests {
@@ -8,5 +8,5 @@ export interface RegularTransactionsRequests {
   }: {
     userId: string
     params?: RegularTransactionSearchParams
-  }) => Promise<ApiResponse<RegularTransaction[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RegularTransaction[]>>
 }

--- a/src/requests/types/rental-records.ts
+++ b/src/requests/types/rental-records.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {RentalRecord, RentalRecordPost} from "../../schema/rental-record"
 
 export interface RentalRecordsRequests {
@@ -6,7 +6,7 @@ export interface RentalRecordsRequests {
     userId,
   }: {
     userId: string
-  }) => Promise<ApiResponse<RentalRecord[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RentalRecord[]>>
 
   createRentalRecord: ({
     userId,
@@ -14,7 +14,7 @@ export interface RentalRecordsRequests {
   }: {
     userId: string
     rentalData: RentalRecordPost
-  }) => Promise<ApiResponse<RentalRecord>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<RentalRecord>>
 
   deleteRentalRecord: ({
     userId,
@@ -22,5 +22,5 @@ export interface RentalRecordsRequests {
   }: {
     userId: string
     rentalId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/savings-goals.ts
+++ b/src/requests/types/savings-goals.ts
@@ -1,10 +1,10 @@
-import {ApiResponse, SearchParams} from "../../request"
+import {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import {SavingsGoal} from "../../schema/savings-goal"
 
 export interface SavingsGoalsRequests {
   getSavingsGoals: (
     params: SearchParams,
-    userId: string
+    userId: string, options?: ExtraOptions
   ) => Promise<ApiResponse<SavingsGoal[]>>
 
   getSavingsGoal: ({
@@ -13,7 +13,7 @@ export interface SavingsGoalsRequests {
   }: {
     goalId: string
     userId: string
-  }) => Promise<ApiResponse<SavingsGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SavingsGoal>>
 
   createSavingsGoal: ({
     name,
@@ -32,7 +32,7 @@ export interface SavingsGoalsRequests {
       currency?: string
     }
     userId: string
-  }) => Promise<ApiResponse<SavingsGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SavingsGoal>>
 
   updateSavingsGoal: ({
     goalId,
@@ -52,7 +52,7 @@ export interface SavingsGoalsRequests {
       value: number
     }
     userId: string
-  }) => Promise<ApiResponse<SavingsGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SavingsGoal>>
 
   deleteSavingsGoal: ({
     goalId,
@@ -60,5 +60,5 @@ export interface SavingsGoalsRequests {
   }: {
     goalId: string
     userId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/spending-analysis.ts
+++ b/src/requests/types/spending-analysis.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {SpendingAnalysis} from "../../schema/spending-analysis"
 
 type Date = {
@@ -20,5 +20,5 @@ export interface SpendingAnalysisRequests {
     accountIds?: string[]
     categoryIds?: string[]
     projectIds?: string[]
-  }) => Promise<ApiResponse<SpendingAnalysis>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SpendingAnalysis>>
 }

--- a/src/requests/types/spending-goals.ts
+++ b/src/requests/types/spending-goals.ts
@@ -1,4 +1,4 @@
-import {ApiResponse, SearchParams} from "../../request"
+import {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import {SpendingGoal} from "../../schema/spending-goal"
 
 type SpendingGoalsPeriodType =
@@ -12,7 +12,7 @@ type Amount = {
 export interface SpendingGoalsRequests {
   getSpendingGoals: (
     params: SearchParams,
-    userId: string
+    userId: string, options?: ExtraOptions
   ) => Promise<ApiResponse<SpendingGoal[]>>
 
   getSpendingGoal: ({
@@ -21,7 +21,7 @@ export interface SpendingGoalsRequests {
   }: {
     goalId: string
     userId: string
-  }) => Promise<ApiResponse<SpendingGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SpendingGoal>>
 
   createSpendingGoal: ({
     categoryId,
@@ -35,7 +35,7 @@ export interface SpendingGoalsRequests {
     periodStart?: string
     amount: Amount
     userId: string
-  }) => Promise<ApiResponse<SpendingGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SpendingGoal>>
 
   updateSpendingGoal: ({
     goalId,
@@ -47,7 +47,7 @@ export interface SpendingGoalsRequests {
     categoryId?: string
     amount?: Amount
     userId: string
-  }) => Promise<ApiResponse<SpendingGoal>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SpendingGoal>>
 
   deleteSpendingGoal: ({
     goalId,
@@ -55,5 +55,5 @@ export interface SpendingGoalsRequests {
   }: {
     goalId: string
     userId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/standing-orders.ts
+++ b/src/requests/types/standing-orders.ts
@@ -1,10 +1,10 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {StandingOrderRequest, StandingOrderSearchParams} from "../../schema/standing-order"
 
 export interface StandingOrdersRequests {
-  getStandingOrder: ({id}: {id: string})
+  getStandingOrder: ({id}: {id: string}, options?: ExtraOptions)
     => Promise<ApiResponse<StandingOrderRequest>>
   getStandingOrders: (
-    params?: StandingOrderSearchParams
+    params?: StandingOrderSearchParams, options?: ExtraOptions
   ) => Promise<ApiResponse<StandingOrderRequest[]>>
 }

--- a/src/requests/types/sync.ts
+++ b/src/requests/types/sync.ts
@@ -1,4 +1,4 @@
-import type {ApiResponse} from "../../request"
+import type {ApiResponse, ExtraOptions} from "../../request"
 import type {SyncResponse} from "../../schema/sync"
 
 export interface SyncRequests {
@@ -12,5 +12,5 @@ export interface SyncRequests {
     connectionId: string
     customerIpAddress?: string
     customerLastLoggedTime?: string
-  }) => Promise<ApiResponse<SyncResponse>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<SyncResponse>>
 }

--- a/src/requests/types/tax.ts
+++ b/src/requests/types/tax.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {Tax, TaxSearchParams} from "../../schema/tax"
 
 export interface TaxRequests {
@@ -8,5 +8,5 @@ export interface TaxRequests {
   }: {
     userId: string
     params?: TaxSearchParams
-  }) => Promise<ApiResponse<Tax>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Tax>>
 }

--- a/src/requests/types/transaction-files.ts
+++ b/src/requests/types/transaction-files.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {TransactionFile} from "../../schema/transaction"
 
 export interface TransactionFilesRequests {
@@ -12,7 +12,7 @@ export interface TransactionFilesRequests {
     transactionId: string
     fileName: string
     fileData: any
-  }) => Promise<ApiResponse<TransactionFile>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionFile>>
 
   getTransactionFiles: ({
     userId,
@@ -20,7 +20,7 @@ export interface TransactionFilesRequests {
   }: {
     userId: string
     transactionId: string
-  }) => Promise<ApiResponse<TransactionFile[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionFile[]>>
 
   getTransactionFile: ({
     userId,
@@ -30,7 +30,7 @@ export interface TransactionFilesRequests {
     userId: string
     transactionId: string
     fileId: string
-  }) => Promise<ApiResponse<TransactionFile>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionFile>>
 
   deleteTransactionFile: ({
     userId,
@@ -40,5 +40,5 @@ export interface TransactionFilesRequests {
     userId: string
     transactionId: string
     fileId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/transaction-splits.ts
+++ b/src/requests/types/transaction-splits.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {TransactionSplit, TransactionSplitPatch, TransactionSplitPost} from "../../schema/transaction"
 
 export interface TransactionSplitsRequests {
@@ -10,7 +10,7 @@ export interface TransactionSplitsRequests {
     userId: string
     transactionId: string
     splits: TransactionSplitPost[]
-  }) => Promise<ApiResponse<TransactionSplit[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionSplit[]>>
 
   getTransactionSplits: ({
     userId,
@@ -18,7 +18,7 @@ export interface TransactionSplitsRequests {
   }: {
     userId: string
     transactionId: string
-  }) => Promise<ApiResponse<TransactionSplit[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionSplit[]>>
 
   patchTransactionSplit: ({
     userId,
@@ -30,7 +30,7 @@ export interface TransactionSplitsRequests {
     transactionId: string
     splitId: string
     split: TransactionSplitPatch
-  }) => Promise<ApiResponse<TransactionSplit[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<TransactionSplit[]>>
 
   deleteTransactionSplits: ({
     userId,
@@ -38,5 +38,5 @@ export interface TransactionSplitsRequests {
   }: {
     userId: string
     transactionId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/types/transactions.ts
+++ b/src/requests/types/transactions.ts
@@ -1,4 +1,4 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {Transaction, TransactionPatch, TransactionPost, TransactionSearchParams} from "../../schema/transaction"
 
 export interface TransactionsRequests {
@@ -8,7 +8,7 @@ export interface TransactionsRequests {
   }: {
     userId: string
     params?: TransactionSearchParams
-  }) => Promise<ApiResponse<Transaction[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Transaction[]>>
 
   getTransaction: ({
     userId,
@@ -16,7 +16,7 @@ export interface TransactionsRequests {
   }: {
     userId: string
     transactionId: string
-  }) => Promise<ApiResponse<Transaction>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Transaction>>
 
   addTransaction: ({
     userId,
@@ -24,7 +24,7 @@ export interface TransactionsRequests {
   }: {
     userId: string
     transaction: TransactionPost
-  }) => Promise<ApiResponse<Transaction>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Transaction>>
 
   addTransactions: ({
     userId,
@@ -36,7 +36,7 @@ export interface TransactionsRequests {
     params?: {
       categorise?: boolean
     }
-  }) => Promise<ApiResponse<{
+  }, options?: ExtraOptions) => Promise<ApiResponse<{
     id: string
   }[]>>
 
@@ -48,7 +48,7 @@ export interface TransactionsRequests {
     userId: string
     transactionId: string
     transaction: TransactionPatch
-  }) => Promise<ApiResponse<Transaction>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<Transaction>>
 
   deleteTransaction: ({
     userId,
@@ -56,5 +56,5 @@ export interface TransactionsRequests {
   }: {
     userId: string
     transactionId: string
-  }) => Promise<ApiResponse<number>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<number>>
 }

--- a/src/requests/types/users-and-connections.ts
+++ b/src/requests/types/users-and-connections.ts
@@ -1,4 +1,4 @@
-import type {ApiResponse, SearchParams} from "../../request"
+import type {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import type {UserConnection} from "../../schema/connection"
 import type {ConnectionSync} from "../../schema/sync"
 import type {User} from "../../schema/user"
@@ -8,27 +8,27 @@ export interface UsersAndConnectionsRequests {
     clientUserId,
   }: {
     clientUserId: string
-  }) => Promise<User>
+  }, options?: ExtraOptions) => Promise<User>
 
   getUsers: (
-    params?: SearchParams
+    params?: SearchParams, options?: ExtraOptions
   ) => Promise<ApiResponse<User[]>>
 
   getSCIMUsers: (
-    params?: SearchParams
+    params?: SearchParams, options?: ExtraOptions
   ) => Promise<ApiResponse<any>>
 
   getUser: ({
     userId,
   }: {
     userId: string
-  }) => Promise<User>
+  }, options?: ExtraOptions) => Promise<User>
 
   getUserConnections: ({
     userId,
   }: {
     userId: string
-  }) => Promise<ApiResponse<UserConnection[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<UserConnection[]>>
 
   deleteUserConnection: ({
     userId,
@@ -36,13 +36,13 @@ export interface UsersAndConnectionsRequests {
   }: {
     userId: string
     connectionId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 
   deleteUser: ({
     userId,
   }: {
     userId: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 
   getConnectionSyncs: ({
     userId,
@@ -52,7 +52,7 @@ export interface UsersAndConnectionsRequests {
     userId: string
     connectionId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<ConnectionSync[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<ConnectionSync[]>>
 
   getUserSyncs: ({
     userId,
@@ -60,7 +60,7 @@ export interface UsersAndConnectionsRequests {
   }: {
     userId: string
     params?: SearchParams
-  }) => Promise<ApiResponse<ConnectionSync[]>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<ConnectionSync[]>>
 
   getSync: ({
     userId,
@@ -68,7 +68,7 @@ export interface UsersAndConnectionsRequests {
   }: {
     userId: string
     syncId: string
-  }) => Promise<ApiResponse<ConnectionSync>>
+  }, options?: ExtraOptions) => Promise<ApiResponse<ConnectionSync>>
 
   updateUserConnection: ({
     userId,
@@ -78,5 +78,5 @@ export interface UsersAndConnectionsRequests {
     userId: string
     connectionId: string
     expiresAt: string
-  }) => Promise<number>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/users-and-connections.ts
+++ b/src/requests/users-and-connections.ts
@@ -7,87 +7,97 @@ export default ({config, request}: RequestsParams): UsersAndConnectionsRequests 
   const scimUsersEndpoint = identityServiceUrl + "/scim/users"
 
   return {
-    registerUser: async ({clientUserId}) =>
+    registerUser: async ({clientUserId}, options) =>
       request(usersEndpoint, {
         method: "POST",
         cc: {
           scope: "user:create",
         },
         body: {clientUserId},
+        options,
       }),
 
-    getUsers: async (params = {}) =>
+    getUsers: async (params = {}, options) =>
       request(usersEndpoint, {
         searchParams: params,
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    getSCIMUsers: async (params = {}) =>
+    getSCIMUsers: async (params = {}, options) =>
       request(scimUsersEndpoint, {
         searchParams: params,
         cc: {
           scope: "scim_user:read",
         },
+        options,
       }),
 
-    getUser: async ({userId}) =>
+    getUser: async ({userId}, options) =>
       request(`${usersEndpoint}/${userId}`, {
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    getUserConnections: async ({userId}) =>
+    getUserConnections: async ({userId}, options) =>
       request(`${usersEndpoint}/${userId}/connections`, {
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    deleteUserConnection: async ({userId, connectionId}) =>
+    deleteUserConnection: async ({userId, connectionId}, options) =>
       request(`${usersEndpoint}/${userId}/connection/${connectionId}`, {
         method: "DELETE",
         returnStatus: true,
         cc: {
           scope: "user:delete",
         },
+        options,
       }),
 
-    deleteUser: async ({userId}) =>
+    deleteUser: async ({userId}, options) =>
       request(`${usersEndpoint}/${userId}`, {
         method: "DELETE",
         returnStatus: true,
         cc: {
           scope: "user:delete",
         },
+        options,
       }),
 
-    getConnectionSyncs: async ({userId, connectionId, params = {}}) =>
+    getConnectionSyncs: async ({userId, connectionId, params = {}}, options) =>
       request(`${usersEndpoint}/${userId}/connections/${connectionId}/syncs`, {
         searchParams: params,
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    getUserSyncs: async ({userId, params = {}}) =>
+    getUserSyncs: async ({userId, params = {}}, options) =>
       request(`${usersEndpoint}/${userId}/syncs`, {
         searchParams: params,
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    getSync: async ({userId, syncId}) =>
+    getSync: async ({userId, syncId}, options) =>
       request(`${usersEndpoint}/${userId}/syncs/${syncId}`, {
         cc: {
           scope: "user:read",
         },
+        options,
       }),
 
-    updateUserConnection: async ({userId, connectionId, expiresAt}) =>
+    updateUserConnection: async ({userId, connectionId, expiresAt}, options) =>
       request(`${usersEndpoint}/${userId}/connections/${connectionId}`, {
         method: "PATCH",
         returnStatus: true,
@@ -95,6 +105,7 @@ export default ({config, request}: RequestsParams): UsersAndConnectionsRequests 
           scope: "user:update",
         },
         body: {expiresAt},
+        options,
       }),
   }
 }


### PR DESCRIPTION
This rather large looking PR adds an extra options argument to all authenticated methods in the library. The argument is an object with the following properties:

```js
{
  token: "full.access.token" // if specified will be added to authorisation header of request
  headers: {
    Authorization: "Bearer full.access.token" // can be used to specify authorisation header or additional headers
  }
}
```
Tests are added to verify that the extra options behave as expected.

This could possibly be published as a minor semver update as the extra argument is optional, any install of this code will have no effect on existing users.