### PR TITLE
Add regular transaction detect

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -104,6 +104,7 @@ describe("API client", function() {
         "getStandingOrder",
         "getStandingOrders",
         "getRegularTransactions",
+        "detectRegularTransactions",
         "getRentalRecords",
         "createRentalRecord",
         "deleteRentalRecord",

--- a/src/__tests__/regular-transactions.ts
+++ b/src/__tests__/regular-transactions.ts
@@ -1,23 +1,31 @@
 /* eslint-disable max-nested-callbacks */
 import {expect} from "chai"
-import {expectTypeOf} from "expect-type"
 
-import {Moneyhub, MoneyhubInstance, RegularTransactions} from ".."
+import {Moneyhub, MoneyhubInstance} from ".."
 
-describe.skip("Regular transactions", function() {
+describe("Regular transactions", function() {
   let moneyhub: MoneyhubInstance
   let userId: string
+  let accountId: string
 
   before(async function() {
     userId = this.config.testUserId
+    accountId = this.config.testAccountId
     moneyhub = await Moneyhub(this.config)
   })
 
-  it("get regular transactions", async function() {
-    const {data} = await moneyhub.getRegularTransactions({userId})
-    expect(data.length).to.be.above(0)
-    expect(data[0]).to.have.property("seriesId")
-    expectTypeOf<RegularTransactions.RegularTransaction[]>(data)
+  describe("Get regular transactions", function() {
+    it("is successful", async function() {
+      const {data} = await moneyhub.getRegularTransactions({userId})
+      expect(data.length).to.eql(0)
+    })
+  })
+
+  describe("Regular transactions detect", function() {
+    it("is successful", async function() {
+      const {data} = await moneyhub.detectRegularTransactions({userId, accountId})
+      expect(data.length).to.eql(0)
+    })
   })
 
 })

--- a/src/requests/regular-transactions.ts
+++ b/src/requests/regular-transactions.ts
@@ -17,5 +17,18 @@ export default ({config, request}: RequestsParams): RegularTransactionsRequests 
           options,
         },
       ),
+
+    detectRegularTransactions: async ({userId, accountId}, options) =>
+      request(
+        `${resourceServerUrl}/regular-transactions/${accountId}/detect`,
+        {
+          cc: {
+            scope: "accounts:read regular_transactions:write regular_transactions:read transactions:read:all",
+            sub: userId,
+          },
+          options,
+          method: "POST",
+        },
+      ),
   }
 }

--- a/src/requests/types/regular-transactions.ts
+++ b/src/requests/types/regular-transactions.ts
@@ -9,4 +9,12 @@ export interface RegularTransactionsRequests {
     userId?: string
     params?: RegularTransactionSearchParams
   }, options?: ExtraOptions) => Promise<ApiResponse<RegularTransaction[]>>
+
+  detectRegularTransactions: ({
+    userId,
+    accountId,
+  }: {
+    userId?: string
+    accountId: string
+  }, options?: ExtraOptions) => Promise<ApiResponse<RegularTransaction[]>>
 }


### PR DESCRIPTION
API-163

This change adds the regular transaction detect functionality. 

Works just like the get regular transactions but requires an accountId instead of it being optional and hits the detect endpoint. 