### PR TITLE
Add automatic versioning to api urls with customisation

### DIFF
--- a/src/__tests__/request.ts
+++ b/src/__tests__/request.ts
@@ -1,0 +1,33 @@
+import {expect} from "chai"
+import {addVersionToUrl} from "../request"
+
+describe("addVersionToUrl", function() {
+  it("should not add a version to an identity url", function() {
+    const url = "https://identity.moneyhub.co.uk"
+    expect(addVersionToUrl(url), url)
+  })
+
+  it("should add the default version to a URL without a version", function() {
+    const url = "https://api.moneyhub.co.uk"
+    const expected = "https://api.moneyhub.co.uk/v3"
+    expect(addVersionToUrl(url), expected)
+  })
+
+  it("should not add the default version to a URL that already has a version", function() {
+    const url = "https://api.moneyhub.co.uk/v2"
+    expect(addVersionToUrl(url), url)
+  })
+
+  it("should add a specified version to a URL without a version", function() {
+    const url = "https://api.moneyhub.co.uk"
+    const version = "v2"
+    const expected = "https://api.moneyhub.co.uk/v2"
+    expect(addVersionToUrl(url, version), expected)
+  })
+
+  it("should not add a specified version to a URL that already has a version", function() {
+    const url = "https://api.moneyhub.co.uk/v2"
+    const version = "v3"
+    expect(addVersionToUrl(url, version), url)
+  })
+})


### PR DESCRIPTION
API-379

This change adds functionality to add a version to your API urls. 

With no version it defaults to v3, if you add a version to the URL then it will use this, if you add a version in options it will use this next.

Identity urls are specifically checked for and untouched.

Tests were written by my good friend co-pilot, and seem to be pretty solid! 