### PR TITLE
Add splicing of version to the urls

### DIFF
--- a/src/__tests__/request.ts
+++ b/src/__tests__/request.ts
@@ -4,35 +4,61 @@ import {addVersionToUrl} from "../request"
 describe("addVersionToUrl", function() {
   it("should not add a version to an identity url", function() {
     const url = "https://identity.moneyhub.co.uk"
-    expect(addVersionToUrl(url, true), url)
+    expect(addVersionToUrl(url, true)).to.eql(url)
   })
 
   it("should add the default version to a URL without a version", function() {
     const url = "https://api.moneyhub.co.uk"
     const expected = "https://api.moneyhub.co.uk/v3"
-    expect(addVersionToUrl(url, true), expected)
+    expect(addVersionToUrl(url, true)).to.eql(expected)
+  })
+
+  it("should add the default version to a URL without a version but a path", function() {
+    const url = "https://api.moneyhub.co.uk/transactions"
+    const expected = "https://api.moneyhub.co.uk/v3/transactions"
+    expect(addVersionToUrl(url, true)).to.eql(expected)
+  })
+
+  it("should add the default version to a URL without a version but a long path", function() {
+    const url = "https://api.moneyhub.co.uk/transactions/1234/data"
+    const expected = "https://api.moneyhub.co.uk/v3/transactions/1234/data"
+    expect(addVersionToUrl(url, true)).to.eql(expected)
   })
 
   it("should not add the default version to a URL that already has a version", function() {
     const url = "https://api.moneyhub.co.uk/v2"
-    expect(addVersionToUrl(url, true), url)
+    expect(addVersionToUrl(url, true)).to.eql(url)
   })
 
   it("should add a specified version to a URL without a version", function() {
     const url = "https://api.moneyhub.co.uk"
     const version = "v2"
     const expected = "https://api.moneyhub.co.uk/v2"
-    expect(addVersionToUrl(url, true, version), expected)
+    expect(addVersionToUrl(url, true, version)).to.eql(expected)
+  })
+
+  it("should add a specified version to a URL without a version but a path", function() {
+    const url = "https://api.moneyhub.co.uk/transactions"
+    const version = "v2"
+    const expected = "https://api.moneyhub.co.uk/v2/transactions"
+    expect(addVersionToUrl(url, true, version)).to.eql(expected)
+  })
+
+  it("should add a specified version to a URL without a version but a long path", function() {
+    const url = "https://api.moneyhub.co.uk/transactions/1234/data"
+    const version = "v2"
+    const expected = "https://api.moneyhub.co.uk/v2/transactions/1234/data"
+    expect(addVersionToUrl(url, true, version)).to.eql(expected)
   })
 
   it("should not add a specified version to a URL that already has a version", function() {
     const url = "https://api.moneyhub.co.uk/v2"
     const version = "v3"
-    expect(addVersionToUrl(url, true, version), url)
+    expect(addVersionToUrl(url, true, version)).to.eql(url)
   })
 
   it("should not add a version to a URL if apiVersioning is false", function() {
     const url = "127.0.0.1:12345"
-    expect(addVersionToUrl(url, false), url)
+    expect(addVersionToUrl(url, false)).to.eql(url)
   })
 })

--- a/src/request.ts
+++ b/src/request.ts
@@ -77,9 +77,14 @@ const attachErrorDetails = (err: unknown) => {
 }
 
 export const addVersionToUrl = (url: string, apiVersioning: boolean, version: Version = "v3"): string => {
-  if (!apiVersioning) return url
-  if (url.includes("identity")) return url
-  return /\/v.+/g.test(url) ? url : `${url}/${version}`
+  if (!apiVersioning || url.includes("identity") || /\/v.+/g.test(url)) return url
+  const urlWithVersion = R.pipe(
+    R.split("/"), // split url [ "https:", "", "test.com", "path", "path2" ]
+    R.insert(3, String(version)), // insert and stringify version after domain
+    R.join("/"), // join url back together with slash
+  )(url)
+
+  return urlWithVersion
 }
 
 export default ({


### PR DESCRIPTION
API-379

This change improves upon the versioning in the client and will splice the version into the URL when using a path.