### PR TITLE
Update jose and OIDC client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "form-data": "^3.0.1",
         "got": "^11.8.5",
-        "jose": "^4.9.3",
-        "openid-client": "^4.9.1",
+        "jose": "^5.2.3",
+        "openid-client": "^5.6.5",
         "query-string": "^7.1.1",
         "ramda": "^0.27.2"
       },
@@ -705,18 +705,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1020,14 +1008,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cliui": {
@@ -2282,14 +2262,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2400,9 +2372,9 @@
       "dev": true
     },
     "node_modules/jose": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.3.tgz",
-      "integrity": "sha512-f8E/z+T3Q0kA9txzH2DKvH/ds2uggcw0m3vVPSB9HrSkrQ7mojjifvS7aR8cw+lQl2Fcmx9npwaHpM/M3GD8UQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2614,7 +2586,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -2947,9 +2920,9 @@
       }
     },
     "node_modules/oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -2975,45 +2948,25 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.9.1.tgz",
-      "integrity": "sha512-DYUF07AHjI3QDKqKbn2F7RqozT4hyi4JvmpodLrq0HHoNP7t/AjeG/uqiBK1/N2PZSAQEThVjDLHSmJN4iqu/w==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
+      "integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
       "dependencies": {
-        "aggregate-error": "^3.1.0",
-        "got": "^11.8.0",
-        "jose": "^2.0.5",
+        "jose": "^4.15.5",
         "lru-cache": "^6.0.0",
-        "make-error": "^1.3.6",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
-      },
-      "engines": {
-        "node": "^10.19.0 || >=12.0.0 < 13 || >=13.7.0 < 14 || >= 14.2.0"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/openid-client/node_modules/jose": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-      "dependencies": {
-        "@panva/asn1.js": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0 < 13 || >=13.7.0"
-      },
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/jose/node_modules/@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/optionator": {
@@ -4524,15 +4477,6 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4762,11 +4706,6 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -5708,11 +5647,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
-    "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5796,9 +5730,9 @@
       "dev": true
     },
     "jose": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.9.3.tgz",
-      "integrity": "sha512-f8E/z+T3Q0kA9txzH2DKvH/ds2uggcw0m3vVPSB9HrSkrQ7mojjifvS7aR8cw+lQl2Fcmx9npwaHpM/M3GD8UQ=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -5958,7 +5892,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "md5": {
       "version": "2.3.0",
@@ -6201,9 +6136,9 @@
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6223,33 +6158,20 @@
       }
     },
     "openid-client": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.9.1.tgz",
-      "integrity": "sha512-DYUF07AHjI3QDKqKbn2F7RqozT4hyi4JvmpodLrq0HHoNP7t/AjeG/uqiBK1/N2PZSAQEThVjDLHSmJN4iqu/w==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
+      "integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
       "requires": {
-        "aggregate-error": "^3.1.0",
-        "got": "^11.8.0",
-        "jose": "^2.0.5",
+        "jose": "^4.15.5",
         "lru-cache": "^6.0.0",
-        "make-error": "^1.3.6",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       },
       "dependencies": {
         "jose": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-          "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-          "requires": {
-            "@panva/asn1.js": "^1.0.0"
-          },
-          "dependencies": {
-            "@panva/asn1.js": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-              "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
-            }
-          }
+          "version": "4.15.5",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+          "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "form-data": "^3.0.1",
     "got": "^11.8.5",
-    "jose": "^4.9.3",
-    "openid-client": "^4.9.1",
+    "jose": "^5.2.3",
+    "openid-client": "^5.6.5",
     "query-string": "^7.1.1",
     "ramda": "^0.27.2"
   },

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -178,7 +178,7 @@ describe("API client", function() {
 
       it("lists test connections", async function() {
         const connections = await moneyhub.listTestConnections()
-        expect(connections.length).to.be.lessThan(10)
+        expect(connections.length).to.be.lessThan(15)
       })
 
       it("gets OpenID config", async function() {

--- a/src/schema/config.ts
+++ b/src/schema/config.ts
@@ -1,3 +1,5 @@
+import type {JWK} from "jose"
+
 export type use = "sig" | "enc";
 export type keyOperation = "sign" | "verify" | "encrypt" | "decrypt" | "wrapKey" | "unwrapKey" | "deriveKey";
 export type ECCurve = "P-256" | "secp256k1" | "P-384" | "P-521";
@@ -46,9 +48,6 @@ export interface JWKRSAKey extends KeyParameters {
   qi?: string
 }
 
-export type JSONWebKey = JWKRSAKey | JWKOKPKey | JWKECKey | JWKOctKey;
-
-
 export type TokenSigningAlgorithm =
   | "HS256"
   | "HS384"
@@ -96,6 +95,6 @@ export interface ApiClientConfig {
     request_object_signing_alg: TokenSigningAlgorithm
     redirect_uri: string
     response_type: ResponseType
-    keys: JSONWebKey[]
+    keys: JWK[]
   }
 }


### PR DESCRIPTION
Breaking changes:
[jose](https://github.com/panva/jose/releases/tag/v5.0.0)
[openid-client](https://github.com/panva/node-openid-client/releases/tag/v5.0.0)


- End-Of-Life versions of Node.js as of October 2023 - will have to update readme/docs to show compatibility with node 18+