### PR TITLE
Add payerType: api-payer and payer to payment claims

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1447,8 +1447,9 @@ const url = await moneyhub.getPaymentAuthorizeUrl({
   payeeId: "Id of payee", // required or payee
   payee: "Details of payee to create", // required or payeeId
   payeeType: "Payee type [api-payee|mh-user-account]", // optional - defaults to api-payee
-  payerId: "Id of payer", // required only if payerType is defined
-  payerType: "Payer type [mh-user-account]", // required only if payerId is used
+  payerType: "Payer type [mh-user-account | api-payer]", // required only if payerId or payer is used
+  payerId: "Id of payer", // required only if payerType is defined as mh-user-account
+  payer: "Details of payer to use", // required if using api-payer for payerType
   amount: "Amount in pence to authorize payment",
   payeeRef: "Payee reference",
   payerRef: "Payer reference",
@@ -1500,8 +1501,9 @@ const url = await moneyhub.getReversePaymentAuthorizeUrl({
   amount: "reverse payment amount" // optional
   nonce: "your nonce value", // optional
   claims: claimsObject, // optional
-  payerId: "payer id that will make the payment", // optional
-  payerType: "api-payee|mh-user-account" // optional
+  payerType: "Payer type [mh-user-account | api-payer]", // required only if payerId or payer is used
+  payerId: "payer id that will make the payment", // required if using mh-user-account for payerType
+  payer: "Details of payer to use", // required if using api-payer for payerType
 })
 
 // Scope used with the bankId provided

--- a/src/get-auth-urls.ts
+++ b/src/get-auth-urls.ts
@@ -3,9 +3,9 @@ import type {Client} from "openid-client"
 import * as R from "ramda"
 
 import type {ApiClientConfig} from "./schema/config"
-import {PaymentActorType} from "./schema/payment"
+import {PayerType, PaymentActorType} from "./schema/payment"
 import {StandingOrderFrequency} from "./schema/standing-order"
-import {RequestPayee} from "./schema/payee"
+import {RequestPayee, RequestPayer} from "./schema/payee"
 import {PermissionsAction} from "./requests/types/auth-requests"
 
 const filterUndefined = R.reject(R.isNil)
@@ -471,6 +471,7 @@ export default ({
       payeeRef,
       payeeId,
       payee,
+      payer,
       payeeType,
       amount,
       payerRef,
@@ -487,12 +488,13 @@ export default ({
       bankId: string
       payeeRef: string
       payeeId?: string
-      payeeType?: string
+      payeeType?: PaymentActorType
       amount: number
       payerRef: string
       payerId?: string
       payee?: RequestPayee
-      payerType?: string
+      payer?: RequestPayer
+      payerType?: PayerType
       state?: string
       nonce?: string
       context?: string
@@ -525,6 +527,7 @@ export default ({
               payerRef,
               payeeId,
               payee,
+              payer,
               payeeType,
               payerId,
               payerType,
@@ -560,6 +563,7 @@ export default ({
       claims = {},
       payerId,
       payerType,
+      payer,
       codeChallenge,
     }: {
       bankId: string
@@ -569,7 +573,8 @@ export default ({
       amount: number
       claims?: any
       payerId?: string
-      payerType?: PaymentActorType
+      payerType?: PayerType
+      payer?: RequestPayer
       codeChallenge?: string
     }) => {
       if (!state) {
@@ -594,6 +599,7 @@ export default ({
               payerId,
               payerType,
               paymentId,
+              payer,
               amount,
             },
           },
@@ -638,9 +644,9 @@ export default ({
       bankId: string
       payeeId?: string
       payee?: RequestPayee
-      payeeType?: string
+      payeeType?: PaymentActorType
       payerId?: string
-      payerType?: string
+      payerType?: PayerType
       reference?: string
       validFromDate?: string
       validToDate?: string
@@ -734,9 +740,9 @@ export default ({
       bankId: string
       payeeId?: string
       payee?: RequestPayee
-      payeeType?: string
+      payeeType?: PaymentActorType
       payerId?: string
-      payerType?: string
+      payerType?: PayerType
       reference: string
       frequency: StandingOrderFrequency
       numberOfPayments?: number

--- a/src/schema/payee.ts
+++ b/src/schema/payee.ts
@@ -19,6 +19,12 @@ export interface RequestPayee {
   name: string
 }
 
+export interface RequestPayer {
+  accountNumber: string
+  sortCode: string
+  name: string
+}
+
 export interface PayeesSearchParams extends SearchParams {
   userId?: string
   hasUserId?: boolean

--- a/src/schema/payment.ts
+++ b/src/schema/payment.ts
@@ -1,6 +1,9 @@
 import type {SearchParams} from "../request"
+import {RequestPayer} from "./payee"
 
 export type PaymentActorType = "api-payee" | "mh-user-account"
+
+export type PayerType = "api-payer" | "mh-user-account"
 
 export type PaymentContext =
   | "Other"
@@ -14,7 +17,8 @@ export interface AuthRequestPostPayment {
   payeeType?: PaymentActorType
   payerId?: string
   payerRef: string
-  payerType?: PaymentActorType
+  payerType?: PayerType
+  payer?: RequestPayer
   payerName?: string
   payerEmail?: string
   readRefundAccount?: boolean


### PR DESCRIPTION
- Adds `payer` to claims
- Creates `PayerType` interface for differentiating between payer and payee types