### PR TITLE
Make sub optional in getClientCredentialTokens

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -135,7 +135,7 @@ export default ({
 
     refreshTokens: ({refreshToken}: {refreshToken: string | TokenSet}) => client.refresh(refreshToken),
 
-    getClientCredentialTokens: ({scope, sub}: {scope: string, sub: string}) =>
+    getClientCredentialTokens: ({scope, sub}: {scope: string, sub?: string}) =>
       client.grant({
         grant_type: "client_credentials",
         scope,


### PR DESCRIPTION
The README specifies that `sub` is optional when calling `getClientCredentialTokens` but the typing forces one to be provided.

This PR makes it optional.

https://github.com/moneyhub/moneyhub-api-client#getclientcredentialtokens

>Use this to get a client credentials access token.

```
const tokens = await moneyhub.getClientCredentialTokens({
  scope: "the-required-scope",
  sub: "the user id", // optional
});
```