### PR TITLE
API-1257 Add mTLS options to client configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
       redirect_uri,
       keys,
       token_endpoint_auth_method,
+      mTLS,
     },
   } = config
 
@@ -33,6 +34,10 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
 
   custom.setHttpOptionsDefaults({
     timeout,
+    ...mTLS ? {
+      cert: mTLS.cert,
+      key: mTLS.key,
+    } : {},
   })
 
   const moneyhubIssuer = await Issuer.discover(identityServiceUrl + "/oidc")
@@ -45,6 +50,7 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
       redirect_uri,
       token_endpoint_auth_method,
       request_object_signing_alg,
+      tls_client_certificate_bound_access_tokens: mTLS?.tls_client_certificate_bound_access_tokens || false,
     },
     {keys},
   )
@@ -53,7 +59,7 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
 
   const request = req({
     client,
-    options: {timeout, apiVersioning},
+    options: {timeout, apiVersioning, mTLS},
   })
 
   const moneyhub = {

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,7 +3,7 @@ import {Client} from "openid-client"
 import qs from "query-string"
 import * as R from "ramda"
 
-import type {ApiClientConfig} from "./schema/config"
+import type {ApiClientConfig, MutualTLSOptions} from "./schema/config"
 const DEFAULT_API_VERSION: Version = "v3"
 const DEFAULT_MAX_RETRY_AFTER = 5000
 
@@ -91,13 +91,14 @@ export const addVersionToUrl = (url: string, apiVersioning: boolean, version: Ve
 
 export default ({
   client,
-  options: {timeout, maxRetryAfter = DEFAULT_MAX_RETRY_AFTER, apiVersioning},
+  options: {timeout, maxRetryAfter = DEFAULT_MAX_RETRY_AFTER, apiVersioning, mTLS},
 }: {
   client: Client
   options: {
     timeout?: number
     maxRetryAfter?: number
     apiVersioning: boolean
+    mTLS?: MutualTLSOptions
   }
 // eslint-disable-next-line max-statements, complexity
 }) => async <T>(
@@ -143,6 +144,13 @@ export default ({
 
   if (opts.formData) {
     (gotOpts as any).body = opts.formData
+  }
+
+  if (mTLS) {
+    gotOpts.https = {
+      certificate: mTLS.cert,
+      key: mTLS.key,
+    }
   }
 
   const req = got<T>(formattedUrl, gotOpts)

--- a/src/schema/config.ts
+++ b/src/schema/config.ts
@@ -78,6 +78,12 @@ export type TokenEndpointAuthMethod =
   | "client_secret_jwt"
   | "private_key_jwt";
 
+export interface MutualTLSOptions {
+  tls_client_certificate_bound_access_tokens?: boolean
+  cert: string
+  key: string
+}
+
 interface ApiClientConfigCredentialsBase {
   client_id: string
   token_endpoint_auth_method: TokenEndpointAuthMethod
@@ -86,6 +92,7 @@ interface ApiClientConfigCredentialsBase {
   redirect_uri: string
   response_type: ResponseType
   keys: JWK[]
+  mTLS?: MutualTLSOptions
 }
 
 export interface ApiClientConfigCredentialsBasic extends ApiClientConfigCredentialsBase {


### PR DESCRIPTION
Adds mTLS option to client configuration, allowing certificates and keys to be used with requests made by `got` and `openid-client`