### PR TITLE
API-1217 sub fix

### DIFF
--- a/examples/token/create-jwt-bearer-grant-token.js
+++ b/examples/token/create-jwt-bearer-grant-token.js
@@ -4,29 +4,25 @@ const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
 
 const optionDefinitions = [
-  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "subject", alias: "s", type: String, description: "required (can be userId or clientId)"},
 ]
 
-const usage = commandLineUsage(
-  {
-    header: "Options",
-    optionList: optionDefinitions,
-  }
-)
+const usage = commandLineUsage({
+  header: "Options",
+  optionList: optionDefinitions,
+})
 
 console.log(usage)
 
 const options = commandLineArgs(optionDefinitions)
 
-if (!options.userId) throw new Error("userId needs to be provided")
+if (!options.subject) throw new Error("subject (userId or clientId) needs to be provided")
 
 const start = async () => {
   try {
     const moneyhub = await Moneyhub(config)
 
-    const data = await moneyhub.createJWTBearerGrantToken({
-      sub: options.userId,
-    })
+    const data = await moneyhub.createJWTBearerGrantToken(options.subject)
     console.log(JSON.stringify(data, null, 2))
   } catch (e) {
     console.log(e)

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -89,10 +89,10 @@ export default ({
     redirectUri: redirect_uri,
   })
 
-  const createJWTBearerGrantToken = async (sub: string) => {
+  const createJWTBearerGrantToken = async (subject: string) => {
     if (request_object_signing_alg === "none") throw new Error("request_object_signing_alg can't be 'none'")
 
-    const privateJWK =  keys.find(({alg}) => alg === request_object_signing_alg) as JWK
+    const privateJWK = keys.find(({alg}) => alg === request_object_signing_alg) as JWK
     if (!privateJWK) throw new Error(`Private key with alg ${request_object_signing_alg} missing`)
 
     const privateKey = await jose.importJWK(privateJWK)
@@ -100,7 +100,7 @@ export default ({
     return await createSignedJWT({
       alg: request_object_signing_alg,
       kid: privateJWK.kid,
-      sub,
+      sub: subject,
       audience: `${identityServiceUrl}/oidc`,
       issuer: client_id,
       privateKey,


### PR DESCRIPTION
Small bug:
There was an issue where the `sub` value in the JWT was nested incorrectly.
<img width="1517" alt="Screenshot 2025-01-08 at 13 39 06" src="https://github.com/user-attachments/assets/7b5f2f52-e58f-4ebb-b6b2-9b802e8b1adc" />

Now, after fix - `sub` passed correctly.
<img width="1626" alt="Screenshot 2025-01-08 at 13 38 48" src="https://github.com/user-attachments/assets/183b0863-605d-4e4b-ab5b-a5f091395f42" />

Also, it should generate JWT by `clientId` and not `userId`. So this was fixed as well.