### PR TITLE
Add retry options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,13 @@ const moneyhub = await Moneyhub({
   resourceServerUrl: "https://api.moneyhub.co.uk/v3",
   identityServiceUrl: "https://identity.moneyhub.co.uk",
   options: { // optional
-    timeout: 60000
+    timeout: 60000, // request timeout in milliseconds
+    retry: {
+      limit: 3, // maximum number of retries
+      methods: ["GET", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE"], // HTTP methods to retry
+      statusCodes: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524], // status codes to retry on
+      maxRetryAfter: 5000 // maximum time to wait between retries in milliseconds
+    },
   }
   client: {
     client_id: "your client id",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
     },
   } = config
 
-  const {timeout = DEFAULT_TIMEOUT, apiVersioning = true} = options
-
+  const {timeout = DEFAULT_TIMEOUT, apiVersioning = true, retry = {}} = options
   custom.setHttpOptionsDefaults({
     timeout,
     ...mTLS ? {
@@ -59,7 +58,7 @@ const _Moneyhub = async (apiClientConfig: ApiClientConfig) => {
 
   const request = req({
     client,
-    options: {timeout, apiVersioning, mTLS},
+    options: {timeout, apiVersioning, mTLS, retry},
   })
 
   const moneyhub = {

--- a/src/schema/config.ts
+++ b/src/schema/config.ts
@@ -1,3 +1,4 @@
+import type {Method} from "got"
 import type {JWK} from "jose"
 import {KeyObject} from "tls"
 
@@ -119,6 +120,12 @@ export interface ApiClientConfig {
   options?: {
     timeout?: number
     apiVersioning?: boolean
+    retry?: {
+      limit?: number
+      methods?: Method[]
+      statusCodes?: number[]
+      maxRetryAfter?: number
+    }
   }
   client: ApiClientConfigCredentials
 }


### PR DESCRIPTION
## Description

This allows to control retry options for all requests

This functionality was useful when running the [transaction categorisation ETL](https://github.com/moneyhub/categorisation-etl) to retry posting transactions when there is a gateway error

API-1258 

## Screenshots, Recordings

![Screenshot 2025-01-10 at 10 30 44](https://github.com/user-attachments/assets/dbe59e9d-db27-4cc6-8b03-9b3326c8a51c)
