### PR TITLE
SHOW: Update tests using version option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,8 @@ When making calls to our methods that require authentication, you can provide an
   token: "full.access.token" // if specified will be added to authorisation header of request
   headers: {
     Authorization: "Bearer full.access.token" // can be used to specify authorisation header or additional headers
-  }
+  },
+  version: "v3" // Forces an specific API version when calling the method
 }
 ```
 Example usages
@@ -142,6 +143,12 @@ const accounts = await moneyhub.getAccounts({
   headers: {
     Authorization: "Bearer full.access.token"
   }
+});
+
+const accounts = await moneyhub.getAccountsList({
+  params: {},
+}, {
+  version: "v2"
 });
 ```
 

--- a/src/__tests__/accounts.ts
+++ b/src/__tests__/accounts.ts
@@ -42,7 +42,7 @@ describe("Accounts", function() {
   })
 
   it("get accounts list", async function() {
-    const accounts = await moneyhub.getAccountsList({userId})
+    const accounts = await moneyhub.getAccountsList({userId}, {version: "v2"})
     expect(accounts.data.length).to.be.at.least(2)
     const cashAccount = accounts.data.find(a => a.type === "cash:current")
     const pension = accounts.data.find(a => a.type === "pension")
@@ -56,7 +56,7 @@ describe("Accounts", function() {
   })
 
   it("get accounts list with transactionData", async function() {
-    const accounts = await moneyhub.getAccountsList({userId, params: {showTransactionData: true}})
+    const accounts = await moneyhub.getAccountsList({userId, params: {showTransactionData: true}}, {version: "v2"})
     expect(accounts.data.length).to.be.at.least(2)
     const cashAccount = accounts.data.find(a => a.type === "cash:current")
     const pension = accounts.data.find(a => a.type === "pension")
@@ -70,7 +70,7 @@ describe("Accounts", function() {
   })
 
   it("get accounts list with details", async function() {
-    const accounts = await moneyhub.getAccountsListWithDetails({userId})
+    const accounts = await moneyhub.getAccountsListWithDetails({userId}, {version: "v2"})
     expect(accounts.data.length).to.be.at.least(2)
     const cashAccount = accounts.data.find(a => a.type === "cash:current")
     const pension = accounts.data.find(a => a.type === "pension")
@@ -93,7 +93,7 @@ describe("Accounts", function() {
       params: {
         counterpartiesVersion: "v2",
       },
-    })
+    }, {version: "v2"})
     expect(counterparties.length).to.be.greaterThan(6)
     expectTypeOf<Counterparties.Counterparty[]>(counterparties)
   })

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -191,9 +191,16 @@ describe("API client", function() {
         expect((openIdConfig as any).issuer).to.be.a("string")
       })
 
-      it("gets global counterparties", async function() {
-        const counterparties = await moneyhub.getGlobalCounterparties()
+      it("gets global counterparties v2", async function() {
+        const counterparties = await moneyhub.getGlobalCounterparties({}, {version: "v2"})
         expect(counterparties.data.length).to.be.greaterThan(100)
+        expect(counterparties.data[0].id).to.match(/^global:/)
+      })
+
+      it("gets global counterparties v3", async function() {
+        const counterparties = await moneyhub.getGlobalCounterparties({limit: 100}, {version: "v3"})
+        expect(counterparties.data.length).to.be.equal(100)
+        expect(counterparties.data[0].id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
       })
     })
   })

--- a/src/requests/types/unauthenticated.ts
+++ b/src/requests/types/unauthenticated.ts
@@ -1,10 +1,11 @@
-import {ApiResponse} from "../../request"
+import {ApiResponse, ExtraOptions} from "../../request"
 import {WellKnownConnection} from "../../schema/connection"
 import {GlobalCounterpartiesSearchParams, GlobalCounterparty} from "../../schema/counterparty"
 
 export interface UnauthenticatedRequests {
   getGlobalCounterparties: (
-    params?: GlobalCounterpartiesSearchParams
+    params?: GlobalCounterpartiesSearchParams,
+    options?: ExtraOptions
   ) => Promise<ApiResponse<GlobalCounterparty[]>>
 
   listConnections: (query?: {clientId?: string}) => Promise<WellKnownConnection[]>

--- a/src/requests/unauthenticated.ts
+++ b/src/requests/unauthenticated.ts
@@ -1,13 +1,14 @@
 import qs from "query-string"
-import {RequestsParams} from "../request"
+import {RequestsParams, ExtraOptions} from "../request"
 import {UnauthenticatedRequests} from "./types/unauthenticated"
 
 export default ({config, request}: RequestsParams): UnauthenticatedRequests => {
   const {resourceServerUrl, identityServiceUrl} = config
   return {
-    getGlobalCounterparties: (params = {}) =>
+    getGlobalCounterparties: (params = {}, options?: ExtraOptions) =>
       request(`${resourceServerUrl}/global-counterparties`, {
         searchParams: params,
+        options,
       }),
     listConnections: (query?: {clientId?: string}) =>
       request(`${identityServiceUrl}/oidc/.well-known/all-connections?${query && qs.stringify(query)}`),


### PR DESCRIPTION

Some endpoints are only available in V2 
This updates the tests to force the request to use V2 when appropriate regardless of the config