### PR TITLE
APISD-1390 Update counterparty type

### DIFF
--- a/src/requests/types/unauthenticated.ts
+++ b/src/requests/types/unauthenticated.ts
@@ -1,12 +1,12 @@
 import {ApiResponse, ExtraOptions} from "../../request"
 import {WellKnownConnection} from "../../schema/connection"
-import {GlobalCounterpartiesSearchParams, GlobalCounterparty} from "../../schema/counterparty"
+import {GlobalCounterpartiesSearchParams, GlobalCounterpartyV3} from "../../schema/counterparty"
 
 export interface UnauthenticatedRequests {
   getGlobalCounterparties: (
     params?: GlobalCounterpartiesSearchParams,
     options?: ExtraOptions
-  ) => Promise<ApiResponse<GlobalCounterparty[]>>
+  ) => Promise<ApiResponse<GlobalCounterpartyV3[]>>
 
   listConnections: (query?: {clientId?: string}) => Promise<WellKnownConnection[]>
   listAPIConnections: (query?: {clientId?: string}) => Promise<WellKnownConnection[]>

--- a/src/schema/counterparty.ts
+++ b/src/schema/counterparty.ts
@@ -19,14 +19,19 @@ export interface GlobalCounterpartiesSearchParams extends SearchParams {
   counterpartiesVersion?: "v2" | "v3"
 }
 
-export interface GlobalCounterparty {
+export interface GlobalCounterpartyV3 {
   id: string
-  label: string
-  companyName: string
-  logo: string
-  website: string
-  mcc: {
-    code?: string
-    name?: string
-  }
+  name: string
+  parentId?: string
+  parentName?: string
+  fullCompanyName?: string | null
+  logoUrl?: string | null
+  website?: string | null
+  merchantCategoryCode?: string | null
+  merchantCategoryDescription?: string | null
+  registeredLocation?: string | null
+  categoryId?: string
+  analyticalCategory?: string
+  transactionCategoryId?: string
+  transactionCategory?: string
 }


### PR DESCRIPTION
### Description

A client noticed that the return type for the `getGlobalCounterparties` method is incorrect as it's still on the v2. This changes it so that it has the v3 counterparty return type. I guess this might not be correct for those clients still using the v2 enpdoint, but figure the latest version of the moneyhub-api-client should use the latest counterparties version. Would welcome opinions on this though.