### PR TITLE
Add provider account ID to Moneyhub

### DIFF
--- a/src/schema/account.ts
+++ b/src/schema/account.ts
@@ -86,6 +86,7 @@ export interface Account {
   providerReference?: string
   connectionId?: string
   providerId?: string
+  providerAccountId?: string
   providerParentAccountId?: string
   accountReference?: string
   accountHolderName?: string


### PR DESCRIPTION
Add `providerAccountId` to the `Account` interface to include provider-specific account information.