### PR TITLE
sec: introduce zizmor actions scanner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - master
   schedule:
     - cron: '0 10 * * *'
 
@@ -12,10 +13,15 @@ jobs:
     name: npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: install dependencies
         run: npm ci
-      - uses: oke-py/npm-audit-action@v2.3.0
+
+      - uses: oke-py/npm-audit-action@c2ee44bdb97ee28fe9f41d78779ee0127b687778 # v2.3.0
         with:
           audit_level: moderate
           production_flag: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: '0 10 * * *'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   publish:
     name: Test, Build and publish
-    runs-on: linux-x64-static-ip-2core-8gb
+    runs-on: ubuntu-latest
     # Single run per release: npm allows one publish per version. A matrix over
     # environments would run publish multiple times and the second job would fail.
     # Optional: add `environment: npm` (or another single environment) for approval

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,26 +38,39 @@ jobs:
     # Optional: add `environment: npm` (or another single environment) for approval
     # gates — see header comments.
     steps:
-      - name: Checkout and Setup
-        uses: moneyhub/checkout-and-setup@v1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          quay-io-username: ${{ secrets.QUAY_IO_USERNAME }}
-          quay-io-password: ${{ secrets.QUAY_IO_PASSWORD }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          # Trusted publishing (OIDC) requires Node 22.14.0+ and npm 11.5.1+ per npm docs.
-          # npm-token is still used for registry auth during install (e.g. private scopes);
-          # use a read-only granular token where possible — publish uses OIDC when available.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          registry-url: "https://registry.npmjs.org"
           node-version: "22.22"
+
       - name: Ensure npm supports OIDC trusted publishing
         run: npm install -g npm@^11.5.1
-      - name: Run and Report Unit Tests
-        uses: moneyhub/run-and-report-tests@v1
-        with:
-          test-script: test-ci
-          report-path: test-reports/report.xml
-          name: Integration
+
+      - name: Run Tests
+        shell: bash
+        run: npm run test-ci
         env:
           NODE_CONFIG: ${{ secrets.TEST_CONFIG }}
+
+      - name: Tests Report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: test-reports/report.xml
+          fail_on_failure: true
+          detailed_summary: true
+          check_name: Test Report
+          require_tests: true
+          require_passed_tests: false
+        env:
+          NODE_CONFIG: ${{ secrets.TEST_CONFIG }}
+
       # Publish auth: npm 11.5.1+ exchanges GitHub's OIDC token (id-token: write) for a
       # short-lived publish token when trusted publishing is configured. No NODE_AUTH_TOKEN
       # is required for publish. Provenance is automatic for trusted publishing from GitHub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Tests Report
         if: success() || failure()
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         with:
           report_paths: test-reports/report.xml
           fail_on_failure: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -51,6 +52,18 @@ jobs:
 
       - name: Ensure npm supports OIDC trusted publishing
         run: npm install -g npm@^11.5.1
+
+      - name: Install Dependencies
+        shell: bash
+        run: npm ci --ignore-scripts
+
+      - name: Audit npm signatures
+        shell: bash
+        run: npm audit signatures
+
+      - name: Run install scripts
+        shell: bash
+        run: npm rebuild && npm run prepare --if-present
 
       - name: Run Tests
         shell: bash

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,42 @@
+name: Moneyhub - Github Actions Security with zizmor 🌈
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: linux-x64-static-ip-2core-8gb
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+
+      - name: Run zizmor 🌈
+        shell: bash
+        # Run offline; actions repositories are already scanned, and external actions
+        #  are allowlisted. Not 100% sure how I feel about this.
+        # @see https://docs.zizmor.sh/troubleshooting/#cant-access-orgrepo-missing-or-you-have-no-access
+        run: uvx zizmor --offline --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,11 +13,9 @@ permissions: {}
 jobs:
   zizmor:
     name: Run zizmor 🌈
-    runs-on: ubuntu-latest
+    runs-on: linux-x64-static-ip-2core-8gb
     permissions:
-      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read         # Only needed for private repos. Needed to clone the repo.
-      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,9 +27,6 @@ jobs:
 
       - name: Run zizmor 🌈
         shell: bash
-        # Run offline; actions repositories are already scanned, and external actions
-        #  are allowlisted. Not 100% sure how I feel about this.
-        # @see https://docs.zizmor.sh/troubleshooting/#cant-access-orgrepo-missing-or-you-have-no-access
         run: uvx zizmor --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Run zizmor 🌈
         shell: bash
-        run: uvx zizmor --format=sarif . > results.sarif
+        run: uvx zizmor .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Run zizmor 🌈
-    runs-on: linux-x64-static-ip-2core-8gb
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
     steps:
@@ -30,9 +30,3 @@ jobs:
         run: uvx zizmor --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
-        if: always()
-        with:
-          sarif_file: results.sarif
-          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ jobs:
         # Run offline; actions repositories are already scanned, and external actions
         #  are allowlisted. Not 100% sure how I feel about this.
         # @see https://docs.zizmor.sh/troubleshooting/#cant-access-orgrepo-missing-or-you-have-no-access
-        run: uvx zizmor --offline --format=sarif . > results.sarif
+        run: uvx zizmor --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,6 +32,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
+        if: always()
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Run zizmor 🌈
-    runs-on: linux-x64-static-ip-2core-8gb
+    runs-on: ubuntu-latest
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
       contents: read         # Only needed for private repos. Needed to clone the repo.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI/CD and the npm publish pipeline; misconfiguration could break releases or change the security posture of workflow permissions and checks.
> 
> **Overview**
> Adds a new `zizmor.yml` workflow that runs `uvx zizmor .` on `push`/`pull_request` to `main`, using minimal default permissions and writing `security-events`.
> 
> Hardens existing workflows by **pinning action SHAs** and disabling credential persistence in checkouts. The publish workflow is refactored to run on `ubuntu-latest`, explicitly sets up Node, and adds supply-chain steps (`npm ci --ignore-scripts` + `npm audit signatures` + controlled script execution) plus JUnit test reporting via `mikepenz/action-junit-report`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dddc21400080138252573de417b5747efa3c9a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->