### PR TITLE
Update /transactions/enrich request and response contract

### DIFF
--- a/src/requests/caas/transactions.ts
+++ b/src/requests/caas/transactions.ts
@@ -1,6 +1,6 @@
 import {RequestsParams} from "../../request"
 import type {ApiResponse} from "../../request"
-import {CaasTransaction, CaasTransactionsRequests} from "./types/transactions"
+import {CaasEnrichTransactionsResponse, CaasTransaction, CaasTransactionsRequests} from "./types/transactions"
 
 export default ({config, request}: RequestsParams): CaasTransactionsRequests => {
   const {caasResourceServerUrl} = config
@@ -23,14 +23,14 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
     },
     caasEnrichTransactions: ({transactions}, options) => {
 
-      return request<ApiResponse<CaasTransaction[]>>(
+      return request<CaasEnrichTransactionsResponse>(
         `${caasResourceServerUrl}/transactions/enrich`,
         {
           method: "POST",
           cc: {
             scope: "caas:transactions:write",
           },
-          body: {transactions},
+          body: transactions,
 
           options,
         },

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -1,5 +1,12 @@
 import {ApiResponse, ExtraOptions} from "../../../request"
 
+export interface CaasEnrichTransactionsResponse {
+  data: CaasTransaction[]
+  meta: {
+    errorTransactionIds: string[]
+  }
+}
+
 export interface CaasTransactionInput {
   userId: string
   accountId: string
@@ -30,7 +37,7 @@ export interface CaasTransactionsRequests {
     transactions,
   }: {
     transactions: CaasTransactionInput[]
-  }, options?: ExtraOptions) => Promise<ApiResponse<CaasTransaction[]>>
+  }, options?: ExtraOptions) => Promise<CaasEnrichTransactionsResponse>
   caasGetTransactions: ({
     userId,
     accountId,


### PR DESCRIPTION
- Send raw transactions array as request body instead of wrapping in {transactions: [...]}
- Add CaasEnrichTransactionsResponse type with data as CaasTransaction[] and meta.errorTransactionIds
- Update caasEnrichTransactions return type to use the new response type

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the request body shape and return type for `caasEnrichTransactions`, which can break existing consumers expecting the old `{transactions: ...}` payload and `ApiResponse` wrapper.
> 
> **Overview**
> Updates `caasEnrichTransactions` to POST the raw transactions array (instead of `{transactions: [...]}`) to `/transactions/enrich`.
> 
> Introduces `CaasEnrichTransactionsResponse` and switches the method’s return type from `ApiResponse<CaasTransaction[]>` to `{ data: CaasTransaction[]; meta: { errorTransactionIds: string[] } }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa89a8b3c8f774bd7008d0116512e8a6004ed33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->