### PR TITLE
MON-3347 Caas smoke tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "project": "./tsconfig.json"
   },
   "extends": [

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,3 +4,4 @@
 npm run lint
 npm run build
 npm test
+npm run test-caas

--- a/src/__tests__/caas/delete-account.ts
+++ b/src/__tests__/caas/delete-account.ts
@@ -1,0 +1,62 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import type {CaasTransactionInput} from "../../requests/caas/types/transactions"
+
+const UNIQUE_USER_ID = "de1e7e00-0002-4000-8000-000000000001"
+const UNIQUE_ACCOUNT_ID = "de1e7e00-0002-4000-8000-000000000002"
+const UNIQUE_TRANSACTION_ID = "de1e7e00-0002-4000-8000-000000000003"
+
+describe("DELETE /accounts/{accountId}", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("enriches a transaction under a unique accountId and then deletes the account", function() {
+    this.timeout(30000)
+
+    let deleteStatus: number
+    let getError: unknown
+
+    before(async function() {
+      const uniqueTransaction: CaasTransactionInput = {
+        userId: UNIQUE_USER_ID,
+        accountId: UNIQUE_ACCOUNT_ID,
+        transactionId: UNIQUE_TRANSACTION_ID,
+        accountType: "cash",
+        txCode: "DEB",
+        date: new Date().toISOString(),
+        status: "posted",
+        description: "Unique Delete Account Target Ltd",
+        amount: -1.23,
+        currency: "GBP",
+      }
+
+      await moneyhub.caasEnrichTransactions({transactions: [uniqueTransaction]})
+
+      deleteStatus = await moneyhub.caasDeleteAccount({accountId: UNIQUE_ACCOUNT_ID})
+
+      try {
+        await moneyhub.caasGetTransactions({
+          userId: UNIQUE_USER_ID,
+          accountId: UNIQUE_ACCOUNT_ID,
+          limit: 1000,
+        })
+      } catch (err) {
+        getError = err
+      }
+    })
+
+    it("responds with 204 No Content", function() {
+      expect(deleteStatus).to.equal(204)
+    })
+
+    it("GET /transactions for the deleted account responds with 404", function() {
+      expect(getError).to.be.an("Error")
+      expect((getError as Error).message).to.include("404")
+    })
+  })
+})

--- a/src/__tests__/caas/delete-transaction.ts
+++ b/src/__tests__/caas/delete-transaction.ts
@@ -3,7 +3,10 @@ import {expect} from "chai"
 
 import {Moneyhub, MoneyhubInstance} from "../.."
 import type {CaasTransactionInput} from "../../requests/caas/types/transactions"
-const UNIQUE_TRANSACTION_ID = "de1e7e00-0001-4000-8000-000000000001"
+
+const UNIQUE_USER_ID = "de1e7e00-0001-4000-8000-000000000001"
+const UNIQUE_ACCOUNT_ID = "de1e7e00-0001-4000-8000-000000000002"
+const UNIQUE_TRANSACTION_ID = "de1e7e00-0001-4000-8000-000000000003"
 
 describe("DELETE /accounts/{accountId}/transactions/{transactionId}", function() {
   let moneyhub: MoneyhubInstance
@@ -15,18 +18,13 @@ describe("DELETE /accounts/{accountId}/transactions/{transactionId}", function()
   describe("enriches a unique transaction and then deletes it", function() {
     this.timeout(30000)
 
+    let deleteStatus: number
     let postDeleteList: Awaited<ReturnType<typeof moneyhub.caasGetTransactions>>
 
     before(async function() {
-      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId) {
-        this.skip()
-      }
-
-      const {caas: {userId, accountId}} = this.config
-
       const uniqueTransaction: CaasTransactionInput = {
-        userId,
-        accountId,
+        userId: UNIQUE_USER_ID,
+        accountId: UNIQUE_ACCOUNT_ID,
         transactionId: UNIQUE_TRANSACTION_ID,
         accountType: "cash",
         txCode: "DEB",
@@ -39,12 +37,20 @@ describe("DELETE /accounts/{accountId}/transactions/{transactionId}", function()
 
       await moneyhub.caasEnrichTransactions({transactions: [uniqueTransaction]})
 
-      await moneyhub.caasDeleteTransaction({
-        accountId,
+      deleteStatus = await moneyhub.caasDeleteTransaction({
+        accountId: UNIQUE_ACCOUNT_ID,
         transactionId: UNIQUE_TRANSACTION_ID,
       })
 
-      postDeleteList = await moneyhub.caasGetTransactions({userId, accountId, limit: 1000})
+      postDeleteList = await moneyhub.caasGetTransactions({
+        userId: UNIQUE_USER_ID,
+        accountId: UNIQUE_ACCOUNT_ID,
+        limit: 1000,
+      })
+    })
+
+    it("responds with 204 No Content", function() {
+      expect(deleteStatus).to.equal(204)
     })
 
     it("the deleted transactionId no longer appears in GET /transactions", function() {

--- a/src/__tests__/caas/delete-transaction.ts
+++ b/src/__tests__/caas/delete-transaction.ts
@@ -1,0 +1,56 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import type {CaasTransactionInput} from "../../requests/caas/types/transactions"
+const UNIQUE_TRANSACTION_ID = "de1e7e00-0001-4000-8000-000000000001"
+
+describe("DELETE /accounts/{accountId}/transactions/{transactionId}", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("enriches a unique transaction and then deletes it", function() {
+    this.timeout(30000)
+
+    let postDeleteList: Awaited<ReturnType<typeof moneyhub.caasGetTransactions>>
+
+    before(async function() {
+      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId) {
+        this.skip()
+      }
+
+      const {caas: {userId, accountId}} = this.config
+
+      const uniqueTransaction: CaasTransactionInput = {
+        userId,
+        accountId,
+        transactionId: UNIQUE_TRANSACTION_ID,
+        accountType: "cash",
+        txCode: "DEB",
+        date: new Date().toISOString(),
+        status: "posted",
+        description: "Unique Delete Target Ltd",
+        amount: -9.99,
+        currency: "GBP",
+      }
+
+      await moneyhub.caasEnrichTransactions({transactions: [uniqueTransaction]})
+
+      await moneyhub.caasDeleteTransaction({
+        accountId,
+        transactionId: UNIQUE_TRANSACTION_ID,
+      })
+
+      postDeleteList = await moneyhub.caasGetTransactions({userId, accountId, limit: 1000})
+    })
+
+    it("the deleted transactionId no longer appears in GET /transactions", function() {
+      const returnedIds = postDeleteList.data.map((t) => t.transactionId)
+
+      expect(returnedIds).to.not.include(UNIQUE_TRANSACTION_ID)
+    })
+  })
+})

--- a/src/__tests__/caas/delete-user.ts
+++ b/src/__tests__/caas/delete-user.ts
@@ -1,0 +1,62 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import type {CaasTransactionInput} from "../../requests/caas/types/transactions"
+
+const UNIQUE_USER_ID = "de1e7e00-0003-4000-8000-000000000001"
+const UNIQUE_ACCOUNT_ID = "de1e7e00-0003-4000-8000-000000000002"
+const UNIQUE_TRANSACTION_ID = "de1e7e00-0003-4000-8000-000000000003"
+
+describe("DELETE /users/{userId}", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("enriches a transaction under a unique userId and then deletes the user", function() {
+    this.timeout(30000)
+
+    let deleteStatus: number
+    let getError: unknown
+
+    before(async function() {
+      const uniqueTransaction: CaasTransactionInput = {
+        userId: UNIQUE_USER_ID,
+        accountId: UNIQUE_ACCOUNT_ID,
+        transactionId: UNIQUE_TRANSACTION_ID,
+        accountType: "cash",
+        txCode: "DEB",
+        date: new Date().toISOString(),
+        status: "posted",
+        description: "Unique Delete User Target Ltd",
+        amount: -2.34,
+        currency: "GBP",
+      }
+
+      await moneyhub.caasEnrichTransactions({transactions: [uniqueTransaction]})
+
+      deleteStatus = await moneyhub.caasDeleteUser({userId: UNIQUE_USER_ID})
+
+      try {
+        await moneyhub.caasGetTransactions({
+          userId: UNIQUE_USER_ID,
+          accountId: UNIQUE_ACCOUNT_ID,
+          limit: 1000,
+        })
+      } catch (err) {
+        getError = err
+      }
+    })
+
+    it("responds with 204 No Content", function() {
+      expect(deleteStatus).to.equal(204)
+    })
+
+    it("GET /transactions for the deleted user responds with 404", function() {
+      expect(getError).to.be.an("Error")
+      expect((getError as Error).message).to.include("404")
+    })
+  })
+})

--- a/src/__tests__/caas/get-counterparties.ts
+++ b/src/__tests__/caas/get-counterparties.ts
@@ -26,7 +26,7 @@ describe("GET /counterparties", function() {
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+      if (this.skipTestsRequiringCaasIds || this.skipSwaggerTests) {
         this.skip()
       }
 

--- a/src/__tests__/caas/get-counterparties.ts
+++ b/src/__tests__/caas/get-counterparties.ts
@@ -1,0 +1,76 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+
+import {
+  fetchSwaggerSpec,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+import {assertTypeMatchesSwagger} from "./typescript-validator"
+
+const TYPES_FILE = "../../../requests/caas/types/transactions.ts"
+
+describe("GET /counterparties", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("fetches counterparties and validates against swagger schema", function() {
+    this.timeout(30000)
+
+    let response: Awaited<ReturnType<typeof moneyhub.caasGetCounterparties>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+        this.skip()
+      }
+
+      response = await moneyhub.caasGetCounterparties({limit: 1000})
+
+      const spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+      const resValidator = createResponseValidator(spec, "/counterparties", "get", "200")
+      if (!resValidator) throw new Error("Swagger schema missing for GET /counterparties")
+      validateResponse = resValidator
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("response contains the seeded counterparties", function() {
+      const returnedIds = response.data.map((c) => c.l3CounterpartyId)
+
+      this.counterpartyIds.forEach((seededId: string) => {
+        expect(returnedIds).to.include(seededId)
+      })
+    })
+
+    it("counterparties have the expected shape", function() {
+      const first = response.data[0]
+
+      expect(first).to.have.property("l3CounterpartyId")
+    })
+  })
+
+  describe("TypeScript types match swagger definitions", function() {
+    this.timeout(30000)
+
+    let spec: Awaited<ReturnType<typeof fetchSwaggerSpec>>
+
+    before(async function() {
+      if (this.skipSwaggerTests) {
+        this.skip()
+      }
+      spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+    })
+
+    it("CaasCounterparty matches swagger Counterparty definition", function() {
+      assertTypeMatchesSwagger({tsType: "CaasCounterparty", tsFile: TYPES_FILE, swaggerDefinitionName: "Counterparty", spec})
+    })
+  })
+})

--- a/src/__tests__/caas/get-enhanced-transaction.ts
+++ b/src/__tests__/caas/get-enhanced-transaction.ts
@@ -43,7 +43,7 @@ describe("GET /accounts/{accountId}/transactions/{transactionId}/enhanced", func
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringEnhancedTransactions || this.skipTestsRequiringAccountId) {
+      if (this.skipTestsRequiringEnhancedTransactions || this.skipTestsRequiringCaasIds) {
         this.skip()
       }
 

--- a/src/__tests__/caas/get-enhanced-transaction.ts
+++ b/src/__tests__/caas/get-enhanced-transaction.ts
@@ -1,0 +1,72 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import {
+  fetchSwaggerSpec,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+import {assertTypeMatchesSwagger} from "./typescript-validator"
+
+const TYPES_FILE = "../../../requests/caas/types/enhanced-transactions.ts"
+
+describe("GET /accounts/{accountId}/transactions/{transactionId}/enhanced", function() {
+  this.timeout(30000)
+
+  let moneyhub: MoneyhubInstance
+  let spec: Awaited<ReturnType<typeof fetchSwaggerSpec>>
+
+  before(async function() {
+    if (this.skipSwaggerTests) {
+      this.skip()
+    }
+    spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("swagger schema", function() {
+    it("has a compilable 200 response schema", function() {
+      const validateResponse = createResponseValidator(spec, "/accounts/{accountId}/transactions/{transactionId}/enhanced", "get", "200")
+      expect(validateResponse, "Swagger schema missing for GET /accounts/{accountId}/transactions/{transactionId}/enhanced").to.exist
+    })
+  })
+
+  describe("TypeScript types match swagger definitions", function() {
+    it("CaasEnhancedTransaction matches swagger EnhancedLocationData definition", function() {
+      assertTypeMatchesSwagger({tsType: "CaasEnhancedTransaction", tsFile: TYPES_FILE, swaggerDefinitionName: "EnhancedLocationData", spec})
+    })
+  })
+
+  describe("fetches an enhanced transaction and validates against swagger schema", function() {
+    let response: Awaited<ReturnType<typeof moneyhub.caasGetEnhancedTransaction>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringEnhancedTransactions || this.skipTestsRequiringAccountId) {
+        this.skip()
+      }
+
+      const {caas: {accountId}} = this.config
+      const [transactionId] = this.transactionIds
+
+      response = await moneyhub.caasGetEnhancedTransaction({accountId, transactionId})
+
+      const resValidator = createResponseValidator(spec, "/accounts/{accountId}/transactions/{transactionId}/enhanced", "get", "200")
+      if (!resValidator) throw new Error("Swagger schema missing for GET /accounts/{accountId}/transactions/{transactionId}/enhanced")
+      validateResponse = resValidator
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("response is for the requested transaction", function() {
+      const {caas: {accountId}} = this.config
+      const [transactionId] = this.transactionIds
+
+      expect(response.data.accountId).to.equal(accountId)
+      expect(response.data.transactionId).to.equal(transactionId)
+    })
+  })
+})

--- a/src/__tests__/caas/get-geotags.ts
+++ b/src/__tests__/caas/get-geotags.ts
@@ -26,7 +26,7 @@ describe("GET /geotags", function() {
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+      if (this.skipTestsRequiringCaasIds || this.skipSwaggerTests) {
         this.skip()
       }
 

--- a/src/__tests__/caas/get-geotags.ts
+++ b/src/__tests__/caas/get-geotags.ts
@@ -1,0 +1,80 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+
+import {
+  fetchSwaggerSpec,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+import {assertTypeMatchesSwagger} from "./typescript-validator"
+
+const TYPES_FILE = "../../../requests/caas/types/transactions.ts"
+
+describe("GET /geotags", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("fetches geotags and validates against swagger schema", function() {
+    this.timeout(30000)
+
+    let response: Awaited<ReturnType<typeof moneyhub.caasGetGeotags>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+        this.skip()
+      }
+
+      response = await moneyhub.caasGetGeotags({geotagIds: this.geotagIds})
+
+      const spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+      const resValidator = createResponseValidator(spec, "/geotags", "get", "200")
+      if (!resValidator) throw new Error("Swagger schema missing for GET /geotags")
+      validateResponse = resValidator
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("response contains the requested geotags", function() {
+      const returnedIds = response.data.map((g) => g.geotagId)
+
+      this.geotagIds.forEach((requestedId: string) => {
+        expect(returnedIds).to.include(requestedId)
+      })
+    })
+
+    it("geotags have the expected shape", function() {
+      const first = response.data[0]
+
+      expect(first).to.have.property("geotagId")
+      expect(first).to.have.property("counterpartyName")
+      expect(first).to.have.property("counterpartyLabel")
+      expect(first).to.have.property("latitude")
+      expect(first).to.have.property("longitude")
+    })
+  })
+
+  describe("TypeScript types match swagger definitions", function() {
+    this.timeout(30000)
+
+    let spec: Awaited<ReturnType<typeof fetchSwaggerSpec>>
+
+    before(async function() {
+      if (this.skipSwaggerTests) {
+        this.skip()
+      }
+      spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+    })
+
+    it("CaasGeotag matches swagger Geotag definition", function() {
+      assertTypeMatchesSwagger({tsType: "CaasGeotag", tsFile: TYPES_FILE, swaggerDefinitionName: "Geotag", spec})
+    })
+  })
+})

--- a/src/__tests__/caas/get-regular-transactions.ts
+++ b/src/__tests__/caas/get-regular-transactions.ts
@@ -1,0 +1,70 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import {
+  fetchSwaggerSpec,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+import {assertTypeMatchesSwagger} from "./typescript-validator"
+
+const TYPES_FILE = "../../../requests/caas/types/regular-transactions.ts"
+
+describe("GET /accounts/{accountId}/regular-transactions", function() {
+  this.timeout(30000)
+
+  let moneyhub: MoneyhubInstance
+  let spec: Awaited<ReturnType<typeof fetchSwaggerSpec>>
+
+  before(async function() {
+    if (this.skipSwaggerTests) {
+      this.skip()
+    }
+    spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("swagger schema", function() {
+    it("has a compilable 200 response schema", function() {
+      const validateResponse = createResponseValidator(spec, "/accounts/{accountId}/regular-transactions", "get", "200")
+      expect(validateResponse, "Swagger schema missing for GET /accounts/{accountId}/regular-transactions").to.exist
+    })
+  })
+
+  describe("TypeScript types match swagger definitions", function() {
+    it("CaasRegularTransaction matches swagger RegularTransaction definition", function() {
+      assertTypeMatchesSwagger({tsType: "CaasRegularTransaction", tsFile: TYPES_FILE, swaggerDefinitionName: "RegularTransaction", spec})
+    })
+  })
+
+  describe("fetches regular transactions and validates against swagger schema", function() {
+    let response: Awaited<ReturnType<typeof moneyhub.caasGetRegularTransactions>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringRegularTransactionsAccount) {
+        this.skip()
+      }
+
+      const {caas: {regularTransactionsAccount}} = this.config
+      response = await moneyhub.caasGetRegularTransactions({accountId: regularTransactionsAccount})
+
+      const resValidator = createResponseValidator(spec, "/accounts/{accountId}/regular-transactions", "get", "200")
+      if (!resValidator) throw new Error("Swagger schema missing for GET /accounts/{accountId}/regular-transactions")
+      validateResponse = resValidator
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("every returned regular transaction belongs to the requested account", function() {
+      const {caas: {regularTransactionsAccount}} = this.config
+
+      response.data.forEach((regularTransaction) => {
+        expect(regularTransaction.accountId).to.equal(regularTransactionsAccount)
+      })
+    })
+  })
+})

--- a/src/__tests__/caas/get-transactions.ts
+++ b/src/__tests__/caas/get-transactions.ts
@@ -1,0 +1,59 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import {
+  fetchSwaggerSpec,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+
+describe("GET /transactions", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("fetches transactions and validates against swagger schema", function() {
+    this.timeout(30000)
+
+    let response: Awaited<ReturnType<typeof moneyhub.caasGetTransactions>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+        this.skip()
+      }
+
+      const {caas: {userId, accountId}} = this.config
+
+      response = await moneyhub.caasGetTransactions({userId, accountId})
+
+      const spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+      const resValidator = createResponseValidator(spec, "/transactions", "get", "200")
+      if (!resValidator) throw new Error("Swagger schema missing for GET /transactions")
+      validateResponse = resValidator
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("response contains the seeded transactions", function() {
+      const returnedIds = response.data.map((t) => t.transactionId)
+
+      this.transactionIds.forEach((seededId: string) => {
+        expect(returnedIds).to.include(seededId)
+      })
+    })
+
+    it("every returned transaction belongs to the requested account", function() {
+      const {caas: {accountId}} = this.config
+
+      response.data.forEach((transaction) => {
+        expect(transaction.accountId).to.equal(accountId)
+      })
+    })
+  })
+})

--- a/src/__tests__/caas/get-transactions.ts
+++ b/src/__tests__/caas/get-transactions.ts
@@ -22,7 +22,7 @@ describe("GET /transactions", function() {
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+      if (this.skipTestsRequiringCaasIds || this.skipSwaggerTests) {
         this.skip()
       }
 

--- a/src/__tests__/caas/patch-transaction.ts
+++ b/src/__tests__/caas/patch-transaction.ts
@@ -1,0 +1,73 @@
+/* eslint-disable max-nested-callbacks */
+import {expect} from "chai"
+
+import {Moneyhub, MoneyhubInstance} from "../.."
+import {
+  fetchSwaggerSpec,
+  createRequestValidator,
+  createResponseValidator,
+  assertMatchesSwagger,
+} from "./swagger"
+
+const NEW_L2_CATEGORY_ID = "22"
+
+describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() {
+  let moneyhub: MoneyhubInstance
+
+  before(async function() {
+    moneyhub = await Moneyhub(this.config)
+  })
+
+  describe("patches a transaction and validates against swagger schema", function() {
+    this.timeout(30000)
+
+    let response: Awaited<ReturnType<typeof moneyhub.caasPatchTransaction>>
+    let patchPayload: {l2CategoryId: string}
+    let validateRequest: NonNullable<ReturnType<typeof createRequestValidator>>
+    let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
+
+    before(async function() {
+      if (this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+        this.skip()
+      }
+
+      const {caas: {accountId}} = this.config
+      const transactionId = this.transactionIds[0]
+
+      patchPayload = {l2CategoryId: NEW_L2_CATEGORY_ID}
+
+      response = await moneyhub.caasPatchTransaction({
+        accountId,
+        transactionId,
+        ...patchPayload,
+      })
+
+      const spec = await fetchSwaggerSpec(this.config.caas.swaggerUrl)
+      const reqValidator = createRequestValidator(spec, "/accounts/{accountId}/transactions/{transactionId}", "patch")
+      const resValidator = createResponseValidator(spec, "/accounts/{accountId}/transactions/{transactionId}", "patch", "200")
+      if (!reqValidator || !resValidator) throw new Error("Swagger schema missing for PATCH /accounts/{accountId}/transactions/{transactionId}")
+      validateRequest = reqValidator
+      validateResponse = resValidator
+    })
+
+    it("request payload matches swagger TransactionPatch schema", function() {
+      assertMatchesSwagger(validateRequest, patchPayload, "Request body")
+    })
+
+    it("response matches swagger 200 schema", function() {
+      assertMatchesSwagger(validateResponse, response, "Response")
+    })
+
+    it("response contains the patched transaction", function() {
+      const {caas: {accountId}} = this.config
+      const transactionId = this.transactionIds[0]
+
+      expect(response.data.transactionId).to.equal(transactionId)
+      expect(response.data.accountId).to.equal(accountId)
+    })
+
+    it("patched transaction has the new l2CategoryId", function() {
+      expect(response.data.mhInsights.l2CategoryId).to.equal(NEW_L2_CATEGORY_ID)
+    })
+  })
+})

--- a/src/__tests__/caas/patch-transaction.ts
+++ b/src/__tests__/caas/patch-transaction.ts
@@ -27,7 +27,7 @@ describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() 
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+      if (this.skipTestsRequiringCaasIds || this.skipSwaggerTests) {
         this.skip()
       }
 

--- a/src/__tests__/caas/post-transactions-enrich.ts
+++ b/src/__tests__/caas/post-transactions-enrich.ts
@@ -3,8 +3,6 @@ import {expect} from "chai"
 
 import {Moneyhub, MoneyhubInstance} from "../.."
 import type {CaasTransactionInput} from "../../requests/caas/types/transactions"
-import type {CaasTestConfig} from "./types"
-
 import {
   fetchSwaggerSpec,
   createRequestValidator,
@@ -35,9 +33,7 @@ describe("POST /transactions/enrich", function() {
         this.skip()
       }
 
-      const {caas} = this.config as CaasTestConfig
-      const userId = caas?.userId as string
-      const accountId = caas?.accountId as string
+      const {caas: {userId, accountId}} = this.config
 
       transactionsPayload = [
         {

--- a/src/__tests__/caas/post-transactions-enrich.ts
+++ b/src/__tests__/caas/post-transactions-enrich.ts
@@ -29,7 +29,7 @@ describe("POST /transactions/enrich", function() {
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
     before(async function() {
-      if (this.skipTestsRequiringUserId || this.skipTestsRequiringAccountId || this.skipSwaggerTests) {
+      if (this.skipTestsRequiringCaasIds || this.skipSwaggerTests) {
         this.skip()
       }
 

--- a/src/__tests__/caas/types.ts
+++ b/src/__tests__/caas/types.ts
@@ -1,7 +1,0 @@
-export interface CaasTestConfig {
-  caas?: {
-    swaggerUrl: string
-    userId?: string
-    accountId?: string
-  }
-}

--- a/src/request.ts
+++ b/src/request.ts
@@ -50,8 +50,8 @@ interface RequestOptions extends Pick<Options, "method" | "headers" | "searchPar
 }
 
 interface Links {
-  next?: string
-  prev?: string
+  next?: string | null
+  prev?: string | null
   self: string
 }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -50,8 +50,8 @@ interface RequestOptions extends Pick<Options, "method" | "headers" | "searchPar
 }
 
 interface Links {
-  next?: string | null
-  prev?: string | null
+  next?: string
+  prev?: string
   self: string
 }
 

--- a/src/requests/caas/accounts.ts
+++ b/src/requests/caas/accounts.ts
@@ -6,13 +6,14 @@ export default ({config, request}: RequestsParams): CaasAccountsRequests => {
 
   return {
     caasDeleteAccount: ({accountId}, options) => {
-      return request<void>(
+      return request<number>(
         `${caasResourceServerUrl}/accounts/${accountId}`,
         {
           method: "DELETE",
           cc: {
             scope: "caas:users:delete",
           },
+          returnStatus: true,
 
           options,
         },

--- a/src/requests/caas/transactions.ts
+++ b/src/requests/caas/transactions.ts
@@ -12,7 +12,7 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
   return {
     caasPatchTransaction: ({accountId, transactionId, l2CategoryId}, options) => {
 
-      return request<ApiResponse<CaasTransaction[]>>(
+      return request<ApiResponse<CaasTransaction>>(
         `${caasResourceServerUrl}/accounts/${accountId}/transactions/${transactionId}`,
         {
           method: "PATCH",

--- a/src/requests/caas/transactions.ts
+++ b/src/requests/caas/transactions.ts
@@ -54,13 +54,14 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
       )
     },
     caasDeleteTransaction: ({accountId, transactionId}, options) => {
-      return request<void>(
+      return request<number>(
         `${caasResourceServerUrl}/accounts/${accountId}/transactions/${transactionId}`,
         {
           method: "DELETE",
           cc: {
             scope: "caas:transactions:delete",
           },
+          returnStatus: true,
 
           options,
         },

--- a/src/requests/caas/types/accounts.ts
+++ b/src/requests/caas/types/accounts.ts
@@ -5,5 +5,5 @@ export interface CaasAccountsRequests {
     accountId,
   }: {
     accountId: string
-  }, options?: ExtraOptions) => Promise<void>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/caas/types/enhanced-transactions.ts
+++ b/src/requests/caas/types/enhanced-transactions.ts
@@ -1,58 +1,272 @@
 import {ApiResponse, ExtraOptions} from "../../../request"
 
-export type CaasIncludeFieldTiers =
+type CaasIncludeFieldTiers =
   | "basic"
   | "search_pro"
   | "search_enterprise"
   | "search_enterprise_plus"
 
-export interface CaasLocalizedText {
+interface CaasLocalizedText {
   text?: string
   languageCode?: string
 }
 
-export interface CaasLatLng {
+interface CaasLatLng {
   latitude?: number
   longitude?: number
 }
 
-export interface CaasViewport {
+interface CaasViewport {
   low?: CaasLatLng
   high?: CaasLatLng
 }
 
-export interface CaasPlusCode {
+interface CaasPlusCode {
   globalCode?: string
   compoundCode?: string
 }
 
-export interface CaasAddressComponent {
+interface CaasAddressComponent {
   longText?: string
   shortText?: string
   types?: string[]
   languageCode?: string
 }
 
-export interface CaasEnhancedLocationData {
+interface CaasAddressDescriptorLandmark {
+  name?: string
+  placeId?: string
+  displayName?: CaasLocalizedText
+  types?: string[]
+  spatialRelationship?: string
+  straightLineDistanceMeters?: number
+  travelDistanceMeters?: number
+}
+
+interface CaasAddressDescriptorArea {
+  name?: string
+  placeId?: string
+  displayName?: CaasLocalizedText
+  containment?: string
+}
+
+interface CaasAddressDescriptor {
+  landmarks?: CaasAddressDescriptorLandmark[]
+  areas?: CaasAddressDescriptorArea[]
+}
+
+interface CaasPostalAddress {
+  revision?: number
+  regionCode?: string
+  languageCode?: string
+  postalCode?: string
+  sortingCode?: string
+  administrativeArea?: string
+  locality?: string
+  sublocality?: string
+  addressLines?: string[]
+  recipients?: string[]
+  organization?: string
+}
+
+interface CaasGoogleMapsLinks {
+  directionsUri?: string
+  placeUri?: string
+  writeAReviewUri?: string
+  reviewsUri?: string
+  photosUri?: string
+}
+
+interface CaasTimeZone {
+  id?: string
+  version?: string
+}
+
+interface CaasAccessibilityOptions {
+  wheelchairAccessibleParking?: boolean
+  wheelchairAccessibleEntrance?: boolean
+  wheelchairAccessibleRestroom?: boolean
+  wheelchairAccessibleSeating?: boolean
+}
+
+interface CaasPlaceReference {
+  name?: string
+  id?: string
+}
+
+interface CaasMoney {
+  currencyCode?: string
+  units?: string
+  nanos?: number
+}
+
+interface CaasPriceRange {
+  startPrice?: CaasMoney
+  endPrice?: CaasMoney
+}
+
+interface CaasOpeningHoursPoint {
+  day?: number
+  hour?: number
+  minute?: number
+}
+
+interface CaasOpeningHoursPeriod {
+  open?: CaasOpeningHoursPoint
+  close?: CaasOpeningHoursPoint
+}
+
+interface CaasOpeningHours {
+  openNow?: boolean
+  secondaryHoursType?: string
+  weekdayDescriptions?: string[]
+  periods?: CaasOpeningHoursPeriod[]
+  nextOpenTime?: string
+}
+
+interface CaasGenerativeSummary {
+  overview?: CaasLocalizedText
+  overviewFlagContentUri?: string
+  description?: CaasLocalizedText
+  descriptionFlagContentUri?: string
+}
+
+interface CaasReviewSummaryText {
+  text?: string
+  languageCode?: string
+}
+
+interface CaasReviewSummary {
+  text?: CaasReviewSummaryText
+  flagContentUri?: string
+}
+
+interface CaasNeighborhoodSummary {
+  description?: CaasLocalizedText
+  descriptionFlagContentUri?: string
+}
+
+interface CaasEvConnectorAggregation {
+  type?: string
+  maxChargeRateKw?: number
+  count?: number
+  availableCount?: number
+  outOfServiceCount?: number
+  availabilityLastUpdateTime?: string
+}
+
+interface CaasEvChargeOptions {
+  connectorCount?: number
+  connectorAggregation?: CaasEvConnectorAggregation[]
+}
+
+interface CaasEvChargeAmenitySummary {
+  connectorCount?: number
+  availableCount?: number
+}
+
+interface CaasFuelPrice {
+  type?: string
+  price?: CaasMoney
+  updateTime?: string
+}
+
+interface CaasFuelOptions {
+  fuelPrices?: CaasFuelPrice[]
+}
+
+interface CaasParkingOptions {
+  freeParkingLot?: boolean
+  paidParkingLot?: boolean
+  freeStreetParking?: boolean
+  paidStreetParking?: boolean
+  valetParking?: boolean
+  freeGarageParking?: boolean
+  paidGarageParking?: boolean
+}
+
+interface CaasPaymentOptions {
+  acceptsCreditCards?: boolean
+  acceptsDebitCards?: boolean
+  acceptsCashOnly?: boolean
+  acceptsNfc?: boolean
+}
+
+interface CaasRoutingSummary {
+  distanceMeters?: number
+  duration?: string
+}
+
+interface CaasEnhancedLocationData {
   formattedAddress?: string
   shortFormattedAddress?: string
   adrFormatAddress?: string
   addressComponents?: CaasAddressComponent[]
+  addressDescriptor?: CaasAddressDescriptor
+  postalAddress?: CaasPostalAddress
   location?: CaasLatLng
   viewport?: CaasViewport
   plusCode?: CaasPlusCode
   types?: string[]
-  displayName?: CaasLocalizedText
   businessStatus?: string
+  displayName?: CaasLocalizedText
   primaryType?: string
+  primaryTypeDisplayName?: CaasLocalizedText
   googleMapsUri?: string
+  googleMapsLinks?: CaasGoogleMapsLinks
+  iconBackgroundColor?: string
+  iconMaskBaseUri?: string
   utcOffsetMinutes?: number
+  timeZone?: CaasTimeZone
+  accessibilityOptions?: CaasAccessibilityOptions
+  containingPlaces?: CaasPlaceReference[]
+  subDestinations?: CaasPlaceReference[]
+  pureServiceAreaBusiness?: boolean
   rating?: number
+  userRatingCount?: number
   priceLevel?: string
+  priceRange?: CaasPriceRange
   websiteUri?: string
-  nationalPhoneNumber?: string
   internationalPhoneNumber?: string
+  nationalPhoneNumber?: string
+  regularOpeningHours?: CaasOpeningHours
+  regularSecondaryOpeningHours?: CaasOpeningHours[]
+  currentOpeningHours?: CaasOpeningHours
+  currentSecondaryOpeningHours?: CaasOpeningHours[]
+  editorialSummary?: CaasLocalizedText
+  generativeSummary?: CaasGenerativeSummary
+  reviewSummary?: CaasReviewSummary
+  neighborhoodSummary?: CaasNeighborhoodSummary
   reviews?: unknown[]
+  evChargeOptions?: CaasEvChargeOptions
+  evChargeAmenitySummary?: CaasEvChargeAmenitySummary
+  fuelOptions?: CaasFuelOptions
+  parkingOptions?: CaasParkingOptions
+  paymentOptions?: CaasPaymentOptions
+  routingSummaries?: CaasRoutingSummary[]
+  allowsDogs?: boolean
+  curbsidePickup?: boolean
+  delivery?: boolean
+  dineIn?: boolean
+  goodForChildren?: boolean
+  goodForGroups?: boolean
+  goodForWatchingSports?: boolean
+  liveMusic?: boolean
+  menuForChildren?: boolean
+  outdoorSeating?: boolean
+  reservable?: boolean
+  restroom?: boolean
+  servesBeer?: boolean
+  servesBreakfast?: boolean
+  servesBrunch?: boolean
+  servesCocktails?: boolean
+  servesCoffee?: boolean
+  servesDessert?: boolean
+  servesDinner?: boolean
+  servesLunch?: boolean
+  servesVegetarianFood?: boolean
+  servesWine?: boolean
+  takeout?: boolean
   [key: string]: unknown
 }
 

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -91,7 +91,7 @@ export interface CaasTransactionsRequests {
       transactionId: string
     },
     options?: ExtraOptions,
-  ) => Promise<void>
+  ) => Promise<number>
 }
 
 export interface CaasTransaction {

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -28,6 +28,7 @@ export type CaasTransactionStatus = "pending" | "posted"
 export type CaasL4LoanType =
   | "Unsecured"
   | "Secured"
+  | "Secured Vehicle"
   | "Buy Now Pay Later"
   | "High Cost Short Term Credit"
   | "Debt Collection Agency/Debt Management Plan"

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -11,6 +11,7 @@ export interface CaasEnrichTransactionsResponse {
   data: CaasTransaction[]
   meta: {
     errorTransactionIds: string[]
+    correlationId: string
   }
 }
 

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -142,19 +142,19 @@ export interface CaasCounterparty {
 
 export interface CaasGeotag {
   geotagId: string
-  counterpartyName: string
-  counterpartyLabel: string
-  houseNumber: string | null
-  street: string | null
-  neighbourhood: string | null
-  locality: string | null
-  city: string | null
-  county: string | null
-  region: string | null
-  postcode: string | null
-  latitude: number
-  longitude: number
-  l3CounterpartyCategory: string | null
+  counterpartyName?: string | null
+  counterpartyLabel?: string | null
+  houseNumber?: string | null
+  street?: string | null
+  neighbourhood?: string | null
+  locality?: string | null
+  city?: string | null
+  county?: string | null
+  region?: string | null
+  postcode?: string | null
+  latitude?: number | null
+  longitude?: number | null
+  l3CounterpartyCategory?: string | null
   postcodeEstimated: boolean
-  postcodeErrorKm: number | null
+  postcodeErrorKm?: number | null
 }

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -60,7 +60,7 @@ export interface CaasTransactionsRequests {
       l2CategoryId: string
     },
     options?: ExtraOptions,
-  ) => Promise<ApiResponse<CaasTransaction[]>>
+  ) => Promise<ApiResponse<CaasTransaction>>
   caasEnrichTransactions: (
     {
       transactions,
@@ -94,19 +94,19 @@ export interface CaasTransactionsRequests {
 }
 
 export interface CaasTransaction {
-  userId?: string
+  userId: string | null
   accountId: string
   transactionId: string
   accountType: CaasAccountType
-  txCode?: string
+  txCode: string | null
   date: string
   status: CaasTransactionStatus
   description: string
   amount: number
   currency: string
-  merchantCategoryCode?: string
-  cardPresent?: boolean
-  meta?: Record<string, any>
+  merchantCategoryCode: string | null
+  cardPresent: boolean | null
+  meta: Record<string, any> | null
   mhInsights: CaasTransactionInsights
 }
 

--- a/src/requests/caas/types/users.ts
+++ b/src/requests/caas/types/users.ts
@@ -5,5 +5,5 @@ export interface CaasUsersRequests {
     userId,
   }: {
     userId: string
-  }, options?: ExtraOptions) => Promise<void>
+  }, options?: ExtraOptions) => Promise<number>
 }

--- a/src/requests/caas/users.ts
+++ b/src/requests/caas/users.ts
@@ -6,13 +6,14 @@ export default ({config, request}: RequestsParams): CaasUsersRequests => {
 
   return {
     caasDeleteUser: ({userId}, options) => {
-      return request<void>(
+      return request<number>(
         `${caasResourceServerUrl}/users/${userId}`,
         {
           method: "DELETE",
           cc: {
             scope: "caas:users:delete",
           },
+          returnStatus: true,
 
           options,
         },

--- a/test/caas/hooks.js
+++ b/test/caas/hooks.js
@@ -11,27 +11,46 @@ function printWarning(message) {
   console.warn(`\n${border}\n* ${message}\n${border}\n`)
 }
 
-exports.mochaHooks = async () => {
-  const {caas: {userId, accountId, swaggerUrl} = {}} = config
-
+function buildConfigWarnings({userId, accountId, swaggerUrl, regularTransactionsAccount, shouldTestEnhancedTransactions}) {
   const missing = [
     !userId && "userId",
     !accountId && "accountId",
     !swaggerUrl && "swaggerUrl",
+    !regularTransactionsAccount && "regularTransactionsAccount",
+    !shouldTestEnhancedTransactions && "shouldTestEnhancedTransactions",
   ].filter(Boolean)
 
-  if (missing.length) {
-    printWarning(
-      `MISSING CAAS CONFIG: ${missing.join(", ")} — some tests will be skipped\n\n` +
-      "Expected config structure:\n" +
-      JSON.stringify({
-        caas: {
-          swaggerUrl: "https://<api-gateway>.co.uk/caas/swagger-enrichment-engine.json",
-          userId: "user-id-12345678",
-          accountId: "account-id-12345678",
-        },
-      }, null, 2),
-    )
+  if (!missing.length) return []
+
+  return [
+    `MISSING CAAS CONFIG: ${missing.join(", ")} — some tests were skipped\n\n` +
+    "Expected config structure:\n" +
+    JSON.stringify({
+      caas: {
+        swaggerUrl: "https://<api-gateway>.co.uk/caas/swagger-enrichment-engine.json",
+        userId: "user-id-12345678",
+        accountId: "account-id-12345678",
+        regularTransactionsAccount: "account-id-with-regular-transactions",
+        shouldTestEnhancedTransactions: false,
+      },
+    }, null, 2),
+  ]
+}
+
+exports.mochaHooks = async () => {
+  const {
+    caas: {
+      userId,
+      accountId,
+      swaggerUrl,
+      regularTransactionsAccount,
+      shouldTestEnhancedTransactions = false,
+    } = {},
+  } = config
+  const warnings = buildConfigWarnings({userId, accountId, swaggerUrl, regularTransactionsAccount, shouldTestEnhancedTransactions})
+
+  if (warnings.length) {
+    process.once("exit", () => warnings.forEach(printWarning))
   }
 
   const moneyhub = await setupMoneyhubClient(config)
@@ -43,6 +62,8 @@ exports.mochaHooks = async () => {
       this.skipSwaggerTests = !swaggerUrl
       this.skipTestsRequiringUserId = !userId
       this.skipTestsRequiringAccountId = !accountId
+      this.skipTestsRequiringRegularTransactionsAccount = !regularTransactionsAccount
+      this.skipTestsRequiringEnhancedTransactions = !shouldTestEnhancedTransactions
       this.transactionIds = transactionIds
       this.geotagIds = geotagIds
       this.counterpartyIds = counterpartyIds

--- a/test/caas/hooks.js
+++ b/test/caas/hooks.js
@@ -1,5 +1,7 @@
 const config = require("config")
 const {Moneyhub} = require("../../src/index")
+const {setupTestData} = require("./setup-test-data")
+const {teardownTestData} = require("./teardown-test-data")
 
 const setupMoneyhubClient = async (config) => Moneyhub(config)
 
@@ -32,18 +34,23 @@ exports.mochaHooks = async () => {
     )
   }
 
-  // eslint-disable-next-line no-unused-vars
   const moneyhub = await setupMoneyhubClient(config)
   return {
     async beforeAll() {
+      const {transactionIds, geotagIds, counterpartyIds} = await setupTestData(config, moneyhub)
+
       this.config = config
       this.skipSwaggerTests = !swaggerUrl
       this.skipTestsRequiringUserId = !userId
       this.skipTestsRequiringAccountId = !accountId
+      this.transactionIds = transactionIds
+      this.geotagIds = geotagIds
+      this.counterpartyIds = counterpartyIds
     },
 
+
     async afterAll() {
-      // TODO: Add teardown method
+      await teardownTestData(config, moneyhub)
     }
   }
 }

--- a/test/caas/hooks.js
+++ b/test/caas/hooks.js
@@ -17,7 +17,7 @@ function buildConfigWarnings({userId, accountId, swaggerUrl, regularTransactions
     !accountId && "accountId",
     !swaggerUrl && "swaggerUrl",
     !regularTransactionsAccount && "regularTransactionsAccount",
-    !shouldTestEnhancedTransactions && "shouldTestEnhancedTransactions",
+    shouldTestEnhancedTransactions === undefined && "shouldTestEnhancedTransactions",
   ].filter(Boolean)
 
   if (!missing.length) return []
@@ -44,7 +44,7 @@ exports.mochaHooks = async () => {
       accountId,
       swaggerUrl,
       regularTransactionsAccount,
-      shouldTestEnhancedTransactions = false,
+      shouldTestEnhancedTransactions,
     } = {},
   } = config
   const warnings = buildConfigWarnings({userId, accountId, swaggerUrl, regularTransactionsAccount, shouldTestEnhancedTransactions})
@@ -60,8 +60,7 @@ exports.mochaHooks = async () => {
 
       this.config = config
       this.skipSwaggerTests = !swaggerUrl
-      this.skipTestsRequiringUserId = !userId
-      this.skipTestsRequiringAccountId = !accountId
+      this.skipTestsRequiringCaasIds = !userId || !accountId
       this.skipTestsRequiringRegularTransactionsAccount = !regularTransactionsAccount
       this.skipTestsRequiringEnhancedTransactions = !shouldTestEnhancedTransactions
       this.transactionIds = transactionIds

--- a/test/caas/setup-test-data.js
+++ b/test/caas/setup-test-data.js
@@ -3,6 +3,10 @@ const {transactions} = require("./test-data")
 exports.setupTestData = async function(config, moneyhub) {
   const {caas: {userId, accountId} = {}} = config
 
+  if (!userId || !accountId) {
+    return {transactionIds: [], counterpartyIds: [], geotagIds: []}
+  }
+
   const transactionsWithUserAndAccountIds = transactions.map((trx) => ({...trx, userId, accountId}))
 
   const {data} = await moneyhub.caasEnrichTransactions({transactions: transactionsWithUserAndAccountIds})

--- a/test/caas/setup-test-data.js
+++ b/test/caas/setup-test-data.js
@@ -1,0 +1,31 @@
+const {transactions} = require("./test-data")
+
+exports.setupTestData = async function(config, moneyhub) {
+  const {caas: {userId, accountId} = {}} = config
+
+  const transactionsWithUserAndAccountIds = transactions.map((trx) => ({...trx, userId, accountId}))
+
+  const {data} = await moneyhub.caasEnrichTransactions({transactions: transactionsWithUserAndAccountIds})
+
+  const {transactionIds, counterpartyIds, geotagIds} = data.reduce((acc, curr) => {
+    acc.transactionIds.push(curr.transactionId)
+
+    const counterpartyId = curr.mhInsights?.l3Counterparty?.l3CounterpartyId
+    if (counterpartyId) {
+      acc.counterpartyIds.push(counterpartyId)
+    }
+
+    const geotags = curr.mhInsights?.geotags ?? []
+    geotags.forEach(({geotagId}) => {
+      acc.geotagIds.push(geotagId)
+    })
+
+    return acc
+  }, {transactionIds: [], counterpartyIds: [], geotagIds: []})
+
+  return {
+    transactionIds,
+    counterpartyIds,
+    geotagIds,
+  }
+}

--- a/test/caas/teardown-test-data.js
+++ b/test/caas/teardown-test-data.js
@@ -1,0 +1,19 @@
+
+exports.teardownTestData = async function(config, moneyhub) {
+  const {caas: {userId, accountId} = {}} = config
+
+  try {
+    if (userId) {
+      await moneyhub.caasDeleteUser({userId})
+    } else if (accountId) {
+      await moneyhub.caasDeleteAccount({accountId})
+    } else {
+      console.warn("No userId or accountId defined for caas tests, skipping teardown")
+    }
+
+  } catch (err) {
+    throw new Error(`Failed to teardown caas test data: ${err.message}`, {cause: err})
+  }
+
+  return true
+}

--- a/test/caas/test-data/index.js
+++ b/test/caas/test-data/index.js
@@ -1,0 +1,3 @@
+const transactions = require("./transactions")
+
+module.exports = {transactions}

--- a/test/caas/test-data/transactions.js
+++ b/test/caas/test-data/transactions.js
@@ -18,7 +18,6 @@ const transactions = [
     status: "posted",
     description: "Currys PC World 1234",
     amount: -15.99,
-    currency: "GBP",
   },
 ]
 

--- a/test/caas/test-data/transactions.js
+++ b/test/caas/test-data/transactions.js
@@ -1,0 +1,26 @@
+const transactions = [
+  {
+    transactionId: "08820421-8472-4254-8608-f0d59e3b0a99",
+    accountType: "cash",
+    txCode: "DEB",
+    date: new Date().toISOString(),
+    status: "posted",
+    description: "Aldi Bristol",
+    amount: -45.5,
+    currency: "GBP",
+    cardPresent: true,
+    merchantCategoryCode: "5411",
+  },
+  {
+    transactionId: "3c4e27be-17dd-45e2-9b1e-041623daf123",
+    accountType: "cash",
+    date: new Date().toISOString(),
+    status: "posted",
+    description: "Currys PC World 1234",
+    amount: -15.99,
+    currency: "GBP",
+  },
+]
+
+
+module.exports = transactions


### PR DESCRIPTION
- Adds more caas smoke tests
- Extends Enhanced transaction types
- Add "Secured Vehicle" l4 loan type
- Return status code number for 204 endpoints instead of void
- Correct null/optional fields
- Add test-caas to prepush hook


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client API return types (notably delete endpoints and `caasPatchTransaction`) and loosens/tightens several response models, which may be a breaking change for downstream TypeScript consumers.
> 
> **Overview**
> Adds a broader set of CaaS integration/smoke tests covering deletes (user/account/transaction), patching transactions, fetching transactions/regular-transactions/geotags/counterparties, and enhanced-transaction retrieval, with automatic test data setup/teardown and config-driven skipping.
> 
> Aligns the CaaS client/types to API behavior and swagger: `DELETE` endpoints now return the HTTP status code (via `returnStatus`), `caasPatchTransaction` returns a single transaction, enrichment responses include `meta.correlationId`, and multiple models are updated for correct `null`/optional fields plus a large expansion of enhanced location data and a new `"Secured Vehicle"` `CaasL4LoanType`.
> 
> Dev workflow updates: pre-push now runs `npm run test-caas`, and ESLint parser `ecmaVersion` is bumped to 2020.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8677b5f7d7b68c846c7f65db2f1a9eb5ae2f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->