### PR TITLE
Fix failing smoke tests

### DIFF
--- a/src/__tests__/caas/patch-transaction.ts
+++ b/src/__tests__/caas/patch-transaction.ts
@@ -9,7 +9,7 @@ import {
   assertMatchesSwagger,
 } from "./swagger"
 
-const NEW_L2_CATEGORY_ID = "22"
+const USER_CATEGORY_ID = "22"
 
 describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() {
   let moneyhub: MoneyhubInstance
@@ -22,7 +22,7 @@ describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() 
     this.timeout(30000)
 
     let response: Awaited<ReturnType<typeof moneyhub.caasPatchTransaction>>
-    let patchPayload: {l2CategoryId: string}
+    let patchPayload: {userCategoryId: string}
     let validateRequest: NonNullable<ReturnType<typeof createRequestValidator>>
     let validateResponse: NonNullable<ReturnType<typeof createResponseValidator>>
 
@@ -34,7 +34,7 @@ describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() 
       const {caas: {accountId}} = this.config
       const transactionId = this.transactionIds[0]
 
-      patchPayload = {l2CategoryId: NEW_L2_CATEGORY_ID}
+      patchPayload = {userCategoryId: USER_CATEGORY_ID}
 
       response = await moneyhub.caasPatchTransaction({
         accountId,
@@ -66,8 +66,8 @@ describe("PATCH /accounts/{accountId}/transactions/{transactionId}", function() 
       expect(response.data.accountId).to.equal(accountId)
     })
 
-    it("patched transaction has the new l2CategoryId", function() {
-      expect(response.data.mhInsights.l2CategoryId).to.equal(NEW_L2_CATEGORY_ID)
+    it("patched transaction has the new userCategoryId", function() {
+      expect(response.data.mhInsights.userCategoryId).to.equal(USER_CATEGORY_ID)
     })
   })
 })

--- a/src/requests/caas/transactions.ts
+++ b/src/requests/caas/transactions.ts
@@ -10,7 +10,7 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
   const {caasResourceServerUrl} = config
 
   return {
-    caasPatchTransaction: ({accountId, transactionId, l2CategoryId}, options) => {
+    caasPatchTransaction: ({accountId, transactionId, userCategoryId, recategorisationType = "single"}, options) => {
 
       return request<ApiResponse<CaasTransaction>>(
         `${caasResourceServerUrl}/accounts/${accountId}/transactions/${transactionId}`,
@@ -19,7 +19,8 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
           cc: {
             scope: "caas:transactions:write",
           },
-          body: {l2CategoryId},
+          body: {userCategoryId},
+          searchParams: {recategorisationType},
 
           options,
         },

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -50,16 +50,20 @@ export interface CaasTransactionInput {
   meta?: Record<string, any>
 }
 
+export type CaasRecategorisationType = "single" | "future"
+
 export interface CaasTransactionsRequests {
   caasPatchTransaction: (
     {
       accountId,
       transactionId,
-      l2CategoryId,
+      userCategoryId,
+      recategorisationType,
     }: {
       accountId: string
       transactionId: string
-      l2CategoryId: string
+      userCategoryId: string
+      recategorisationType?: CaasRecategorisationType
     },
     options?: ExtraOptions,
   ) => Promise<ApiResponse<CaasTransaction>>
@@ -120,6 +124,7 @@ export interface CaasTransactionInsights {
   l2CategoryName?: CaasL2CategoryName
   l3Counterparty?: CaasCounterparty | null
   geotags?: CaasGeotag[]
+  userCategoryId?: string | null
   cardPresent: boolean | null
   timestampCreated: string
   timestampIngress: string
@@ -142,8 +147,8 @@ export interface CaasCounterparty {
 
 export interface CaasGeotag {
   geotagId: string
-  counterpartyName?: string | null
-  counterpartyLabel?: string | null
+  counterpartyName: string | null
+  counterpartyLabel: string | null
   houseNumber?: string | null
   street?: string | null
   neighbourhood?: string | null
@@ -152,8 +157,8 @@ export interface CaasGeotag {
   county?: string | null
   region?: string | null
   postcode?: string | null
-  latitude?: number | null
-  longitude?: number | null
+  latitude: number | null
+  longitude: number | null
   l3CounterpartyCategory?: string | null
   postcodeEstimated: boolean
   postcodeErrorKm?: number | null


### PR DESCRIPTION
3 different issues:
- the PATCH /transactions doesn't take an l2 category, it only takes a user category id now
- PATCH /transactions recategorisationType query param is now required
- 4 geotag params seem to have become required now (nothing to do with custom categories, but thought we should fix it) 

MON-3515

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `caasPatchTransaction` request/response types and parameters to match an external API contract change, which is potentially breaking for SDK consumers and could affect transaction recategorisation behavior.
> 
> **Overview**
> Aligns the CaaS transaction PATCH API with the updated contract by switching the patch body from `l2CategoryId` to `userCategoryId` and adding a `recategorisationType` query param (defaulting to `single`).
> 
> Updates the public TypeScript types to reflect the new inputs/outputs, including `mhInsights.userCategoryId` and stricter required fields on `CaasGeotag`, and adjusts the smoke test to assert against `userCategoryId` instead of `l2CategoryId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670ec2deed2610e9b059e82ca4d8debf9f0ac6ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->