### PR TITLE
Add postLlmGatewaySavingsGoals request

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -97,6 +97,7 @@ describe("API client", function() {
         "splitTransaction",
         "getTransactionSplits",
         "patchTransactionSplit",
+        "postLlmGatewaySavingsGoals",
         "deleteTransactionSplits",
         "getGlobalCounterparties",
         "getJWTBearerToken",

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -36,6 +36,7 @@ import usersAndConnections from "./users-and-connections"
 import resellerCheck from "./reseller-check"
 import categoriseTransactions from "./categorise-transactions"
 import consentHistory from "./consent-history"
+import llmGateway from "./llm-gateway"
 
 export default ({config, request}: RequestsParams) => {
   return {
@@ -75,5 +76,6 @@ export default ({config, request}: RequestsParams) => {
     ...resellerCheck({config, request}),
     ...categoriseTransactions({config, request}),
     ...consentHistory({config, request}),
+    ...llmGateway({config, request}),
   }
 }

--- a/src/requests/llm-gateway.ts
+++ b/src/requests/llm-gateway.ts
@@ -1,0 +1,31 @@
+import type {ApiResponse, ExtraOptions, RequestsParams} from "../request"
+
+const LLM_GATEWAY_SAVINGS_GOALS_WRITE_SCOPE = "llm_gateway_savings_goals:write"
+
+export default ({config, request}: RequestsParams) => {
+  const {resourceServerUrl} = config
+
+  return {
+    postLlmGatewaySavingsGoals: async (
+      {userId, body = {}}: {userId: string, body?: Record<string, unknown>},
+      options?: ExtraOptions,
+    ) =>
+      request<ApiResponse<Record<string, unknown>>>(
+        `${resourceServerUrl}/llm-gateway/savings-goals`,
+        {
+          method: "POST",
+          body,
+          cc: options?.token
+            ? undefined
+            : {
+              scope: LLM_GATEWAY_SAVINGS_GOALS_WRITE_SCOPE,
+              sub: userId,
+            },
+          options: {
+            version: "v3",
+            ...options,
+          },
+        },
+      ),
+  }
+}


### PR DESCRIPTION
MON-3945

Add llm-gateway request module and export from the requests index for POST /llm-gateway/savings-goals via API gateway v3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new request wrapper and export without changing existing request behavior; main risk is incorrect scope/version causing runtime API errors.
> 
> **Overview**
> Adds a new `llm-gateway` request module exposing `postLlmGatewaySavingsGoals`, which `POST`s to `/llm-gateway/savings-goals` using API version `v3` and client-credentials scope `llm_gateway_savings_goals:write` (unless an explicit `token` is provided).
> 
> Wires the new module into the requests index export and updates the API client test to expect the new method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099037789e30d2a33e2f7e2d2a7445e0dd0cd040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->