### PR TITLE
Update Caas transaction types

### DIFF
--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -35,7 +35,7 @@ export type CaasL4LoanType =
   | "Debt Collection Agency/Debt Management Plan"
 
 export interface CaasTransactionInput {
-  userId?: string
+  userId?: string | null
   accountId: string
   transactionId: string
   accountType: CaasAccountType
@@ -44,10 +44,10 @@ export interface CaasTransactionInput {
   description: string
   amount: number
   currency?: string
-  txCode?: string
-  merchantCategoryCode?: string
-  cardPresent?: boolean
-  meta?: Record<string, any>
+  txCode?: string | null
+  merchantCategoryCode?: string | null
+  cardPresent?: boolean | null
+  meta?: Record<string, any> | null
 }
 
 export type CaasRecategorisationType = "single" | "future"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only change in the SDK; no runtime or security logic is modified.
> 
> **Overview**
> **`CaasTransactionInput`** now allows explicit **`null`** on several optional fields (`userId`, `txCode`, `merchantCategoryCode`, `cardPresent`, `meta`), not only omission. That aligns the enrich request payload type with **`CaasTransaction`**, where those fields are already `string | null`, `boolean | null`, etc.
> 
> Callers can type payloads that intentionally clear or send null-valued optional data to **`caasEnrichTransactions`** without fighting TypeScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6085693ba247ebf7660b58023e7eb4286b7188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->