### PR TITLE
MON-4025 fix caas smoke tests

### DIFF
--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -6,6 +6,7 @@ import type {
   CaasL2CategoryId,
   CaasL2CategoryName,
 } from "./categories"
+import type {CaasTransactionSplit} from "./transaction-splits"
 
 export interface CaasEnrichTransactionsResponse {
   data: CaasTransaction[]
@@ -48,6 +49,7 @@ export interface CaasTransactionInput {
   merchantCategoryCode?: string | null
   cardPresent?: boolean | null
   meta?: Record<string, any> | null
+  splits?: CaasTransactionSplit[]
 }
 
 export type CaasRecategorisationType = "single" | "future"
@@ -113,6 +115,7 @@ export interface CaasTransaction {
   merchantCategoryCode: string | null
   cardPresent: boolean | null
   meta: Record<string, any> | null
+  splits?: CaasTransactionSplit[]
   mhInsights: CaasTransactionInsights
 }
 


### PR DESCRIPTION
## Description

Adds the optional `splits` field to `CaasTransactionInput` and `CaasTransaction`, aligning the TypeScript types with the swagger `TransactionPost` and `EnrichedTransaction` definitions.

Fixes failing CAAS smoke tests that validate TS types against swagger (`splits: missing from TS type, expected by swagger` on `POST /transactions/enrich`).

The field reuses the existing `CaasTransactionSplit` type from `transaction-splits.ts`, matching the swagger `TransactionSplit` schema (`amount`, `userCategoryId`, `description`).

## Screenshots, Recordings

## This PR includes:

- [ ] Unit tests
- [x] Contract tests
- [ ] Logging
- [ ] Monitoring
- [ ] Dependencies updates
- [ ] Swagger/Documentation changes

## Added config changes?

- [ ] Yes, add more details and remember to add them in ETCD
- [x] No

## Added database migrations/resources (db, collection, table, column)?

- [ ] Yes, please add more details and get them 'signed off' by devsecops team (add them to the PR)
- [x] No

## Are there any post deployment tasks that need to be performed?

No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only additions with optional fields; no logic, auth, or data-path changes.
> 
> **Overview**
> Adds optional **`splits`** on **`CaasTransactionInput`** and **`CaasTransaction`**, importing the existing **`CaasTransactionSplit`** type so CAAS transaction models match swagger **`TransactionPost`** / **`EnrichedTransaction`**.
> 
> This unblocks contract/smoke checks that compare TS types to swagger (e.g. enrich **`POST /transactions/enrich`**), with no runtime or API behavior changes—types only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31f662e6a3eb1581ce0407f4bcc4281ad4271df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->