### PR TITLE
MON-4025 add caas split get transactions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2254,7 +2254,7 @@ const result = await moneyhub.caasEnrichTransactions({
 
 #### `caasGetTransactions`
 
-Get transactions from the CAAS API with optional filtering by user and limit. This function uses the scope `caas:transactions:read`.
+Get transactions from the CAAS API with optional filtering by user and limit. This function uses the scopes `caas:transactions:read caas:transaction_splits:read`. The `splits` array is included for any split transaction when the client is registered for the `caas:transaction_splits:read` scope.
 
 ```javascript
 const result = await moneyhub.caasGetTransactions({

--- a/src/requests/caas/transactions.ts
+++ b/src/requests/caas/transactions.ts
@@ -46,7 +46,7 @@ export default ({config, request}: RequestsParams): CaasTransactionsRequests => 
         `${caasResourceServerUrl}/transactions`,
         {
           cc: {
-            scope: "caas:transactions:read",
+            scope: "caas:transactions:read caas:transaction_splits:read",
           },
           searchParams: {accountId, userId, limit},
 


### PR DESCRIPTION
## Description

Adds the `caas:transaction_splits:read` scope to the `caasGetTransactions` request so transaction splits are returned by `GET /transactions`.

The mh-api-gateway only includes the `splits` array when the access token carries `caas:transaction_splits:read`. Previously the SDK requested only `caas:transactions:read`, so splits were always stripped from the response. The request now asks for both scopes. The client-credentials grant filters requested scopes against the client's allow-list and silently drops any it is not registered for, so clients with the splits scope receive `splits` and clients without it are unaffected (no grant failure, just no splits). No separate method is introduced and the public API surface is unchanged.

## Screenshots, Recordings
<img width="517" height="288" alt="Screenshot 2026-06-09 at 4 05 35 pm" src="https://github.com/user-attachments/assets/4efb7388-b764-4245-8897-93a718ddeaf0" />

## This PR includes:

- [ ] Unit tests
- [ ] Contract tests
- [ ] Logging
- [ ] Monitoring
- [ ] Dependencies updates
- [x] Swagger/Documentation changes

## Added config changes?

- [ ] Yes, add more details and remember to add them in ETCD
- [x] No

## Added database migrations/resources (db, collection, table, column)?

- [x] No

## Are there any post deployment tasks that need to be performed?

Clients that need splits returned must be registered for the `caas:transaction_splits:read` scope in identity. No change is required for clients that do not use splits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OAuth scope change on an existing CAAS read call with no API signature change; unregistered clients should be unaffected by scope filtering at token grant.
> 
> **Overview**
> **`caasGetTransactions`** now requests **`caas:transactions:read`** and **`caas:transaction_splits:read`** on the client-credentials grant (previously only transactions read). The gateway only returns a **`splits`** array when the token includes the splits scope, so this fixes split data being omitted for clients that are allowed that scope.
> 
> The public method signature is unchanged. Clients not registered for **`caas:transaction_splits:read`** should still get tokens without that scope (filtered at grant time) and behave as before. The readme **`caasGetTransactions`** section documents both scopes and when **`splits`** appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d2eceadeee5a5524fb3d69340cee858a687c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->