### PR TITLE
Add check config examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+examples/config.js
 examples/config-local.js
 examples/config.local.js
 config/local.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npm run check-secrets
 npm run lint
 npm run build

--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -1,0 +1,20 @@
+const config = {
+  resourceServerUrl: "https://api.moneyhub.co.uk/v3",
+  identityServiceUrl: "https://identity.moneyhub.co.uk",
+  accountConnectUrl: "https://bank-chooser.moneyhub.co.uk/account-connect.js",
+  client: {
+    client_id: "your client id",
+    client_secret: "your client secret",
+    token_endpoint_auth_method: "client_secret_basic",
+    id_token_signed_response_alg: "RS256",
+    request_object_signing_alg: "none",
+    redirect_uri: "https://your-redirect-uri",
+    response_type: "code",
+    keys: [
+
+      /* your jwks */
+    ],
+  },
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint src/ ",
     "lint-fix": "eslint src/ --fix",
+    "check-secrets": "node scripts/check-secrets.js",
     "test": "mocha --require ts-node/register --config test/opts/integration.json",
     "test-ci": "mocha --require ts-node/register --config test/opts/integration-ci.json",
     "test-caas": "mocha --require ts-node/register --config test/opts/integration-caas.json",

--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const {execSync} = require("child_process")
+
+const blockedPaths = [
+  "examples/config.js",
+]
+
+const secretPatterns = [
+  {
+    name: "PEM private key",
+    regex: /-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----/,
+  },
+  {
+    name: "JWK private component (\"d\")",
+    regex: /"d"\s*:\s*"[A-Za-z0-9_-]{20,}"/,
+  },
+  {
+    name: "Real client_secret value",
+    regex: /client_secret"?\s*[:=]\s*"(?!your client secret")[^"]{8,}"/,
+  },
+]
+
+const getStagedFiles = () => {
+  const output = execSync(
+    "git diff --cached --name-only --diff-filter=ACM",
+    {encoding: "utf8"}
+  )
+  return output.split("\n").map(line => line.trim()).filter(Boolean)
+}
+
+const getStagedContent = file => {
+  try {
+    return execSync(`git show :"${file}"`, {encoding: "utf8"})
+  } catch (err) {
+    return ""
+  }
+}
+
+const scanFile = file => {
+  const findings = []
+  if (blockedPaths.includes(file)) {
+    findings.push(`${file}: file is blocked from being committed (use examples/config.example.js as a template and keep secrets in the git-ignored examples/config.js)`)
+    return findings
+  }
+  const content = getStagedContent(file)
+  secretPatterns.forEach(({name, regex}) => {
+    if (regex.test(content)) {
+      findings.push(`${file}: matched "${name}"`)
+    }
+  })
+  return findings
+}
+
+const main = () => {
+  const files = getStagedFiles()
+  const findings = files.flatMap(scanFile)
+  if (findings.length === 0) {
+    process.exit(0)
+  }
+  console.error("\nCommit blocked: potential secrets detected in staged changes\n")
+  findings.forEach(finding => console.error(`  - ${finding}`))
+  console.error("\nRemove the secrets, unstage the file, and commit again.")
+  console.error("If this is a false positive, review the staged content before bypassing.\n")
+  process.exit(1)
+}
+
+main()

--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -22,19 +22,13 @@ const secretPatterns = [
 
 const getStagedFiles = () => {
   const output = execSync(
-    "git diff --cached --name-only --diff-filter=ACM",
+    "git diff --cached --name-only --diff-filter=ACM --no-renames",
     {encoding: "utf8"}
   )
   return output.split("\n").map(line => line.trim()).filter(Boolean)
 }
 
-const getStagedContent = file => {
-  try {
-    return execSync(`git show :"${file}"`, {encoding: "utf8"})
-  } catch (err) {
-    return ""
-  }
-}
+const getStagedContent = file => execSync(`git show :"${file}"`, {encoding: "utf8"})
 
 const scanFile = file => {
   const findings = []
@@ -42,7 +36,13 @@ const scanFile = file => {
     findings.push(`${file}: file is blocked from being committed (use examples/config.example.js as a template and keep secrets in the git-ignored examples/config.js)`)
     return findings
   }
-  const content = getStagedContent(file)
+  let content
+  try {
+    content = getStagedContent(file)
+  } catch (err) {
+    findings.push(`${file}: unable to read staged content, cannot verify it is secret-free (${err.message})`)
+    return findings
+  }
   secretPatterns.forEach(({name, regex}) => {
     if (regex.test(content)) {
       findings.push(`${file}: matched "${name}"`)

--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-const {execSync} = require("child_process")
+const {execFileSync} = require("child_process")
+
+const git = args => execFileSync("git", args, {encoding: "utf8"})
 
 const blockedPaths = [
   "examples/config.js",
@@ -21,14 +23,11 @@ const secretPatterns = [
 ]
 
 const getStagedFiles = () => {
-  const output = execSync(
-    "git diff --cached --name-only --diff-filter=ACM --no-renames",
-    {encoding: "utf8"}
-  )
+  const output = git(["diff", "--cached", "--name-only", "--diff-filter=ACM", "--no-renames"])
   return output.split("\n").map(line => line.trim()).filter(Boolean)
 }
 
-const getStagedContent = file => execSync(`git show :"${file}"`, {encoding: "utf8"})
+const getStagedContent = file => git(["show", `:${file}`])
 
 const scanFile = file => {
   const findings = []


### PR DESCRIPTION
## Description

Prevents committing credentials in the examples config and stops `examples/config.js` from being tracked.

- Add `examples/config.js` to `.gitignore` so the file holding real credentials is never tracked.
- Add tracked `examples/config.example.js` (clean placeholder template) so the examples retain a config reference once `config.js` is ignored. Devs copy it to `examples/config.js` and fill in their own values.
- Add `scripts/check-secrets.js`, a pre-commit secret scanner that blocks staged changes containing PEM private keys, JWK private components (`"d"`), real `client_secret` values, or `examples/config.js` by name.
- Wire `npm run check-secrets` into `.husky/pre-commit` (runs first, fail fast before lint/build).

## Screenshots, Recordings


## This PR includes:

- [ ] Unit tests
- [ ] Contract tests
- [x] Logging
- [ ] Monitoring
- [ ] Dependencies updates
- [ ] Swagger/Documentation changes

## Added config changes?

- [ ] Yes, add more details and remember to add them in ETCD
- [x] No

## Added database migrations/resources (db, collection, table, column)?

- [ ] Yes, please add more details and get them 'signed off' by devsecops team (add them to the PR)
- [x] No

## Are there any post deployment tasks that need to be performed?

Run `git rm --cached examples/config.js` once so the now-ignored file stops being tracked. Each developer copies `examples/config.example.js` to `examples/config.js` locally. Note: any credentials previously exposed in history must be rotated separately (out of scope for this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer workflow and local git hooks only; no runtime API or production config changes.
> 
> **Overview**
> Stops example OAuth/client credentials from landing in git by ignoring **`examples/config.js`**, adding a tracked **`examples/config.example.js`** placeholder, and running a **pre-commit secret scan** before lint/build.
> 
> **`scripts/check-secrets.js`** scans staged files for PEM private keys, JWK `"d"` values, non-placeholder `client_secret` strings, and blocks commits that include **`examples/config.js`**. **`npm run check-secrets`** is wired into **`.husky/pre-commit`** as the first step.
> 
> Post-merge, teams should **`git rm --cached examples/config.js`** and copy the example file locally; any secrets already in history need rotation separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9bd76bef43e5ef3c2f5f08a55d01ba7506612d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->