### PR TITLE
Local config for widgets

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -1,20 +1,83 @@
-const config = {
-  resourceServerUrl: "https://api.moneyhub.co.uk/v3",
-  identityServiceUrl: "https://identity.moneyhub.co.uk",
-  accountConnectUrl: "https://bank-chooser.moneyhub.co.uk/account-connect.js",
-  client: {
-    client_id: "your client id",
-    client_secret: "your client secret",
-    token_endpoint_auth_method: "client_secret_basic",
-    id_token_signed_response_alg: "RS256",
-    request_object_signing_alg: "none",
-    redirect_uri: "https://your-redirect-uri",
-    response_type: "code",
-    keys: [
+// const config = {
+// 	resourceServerUrl: "http://apigateway.dev.127.0.0.1.nip.io/v2.0",
+// 	identityServiceUrl: "http://identity.dev.127.0.0.1.nip.io/oidc",
+// 	accountConnectUrl: "https://bank-chooser.moneyhub.co.uk/account-connect.js",
+// 	client: {
+// 		client_id: "40e1a1bf-9574-4c83-b87b-82e2266907aa",
+// 		client_secret: "928bae58-7216-46ad-86c2-84fd8151bdcd",
+// 		token_endpoint_auth_method: "client_secret_basic",
+// 		id_token_signed_response_alg: "RS256",
+// 		request_object_signing_alg: "none",
+// 		redirect_uri: "https://invite.moneyhub.co.uk/api/callback",
+// 		response_type: "code",
+// 		keys: [
+// 			/* your jwks */
+// 		],
+// 	},
+// }
 
-      /* your jwks */
-    ],
-  },
+// phoenix local config
+const config = {
+	resourceServerUrl: "http://apigateway.dev.127.0.0.1.nip.io/v2.0",
+	identityServiceUrl: "http://identity.dev.127.0.0.1.nip.io/oidc",
+	accountConnectUrl: "https://bank-chooser.moneyhub.co.uk/account-connect.js",
+	client: {
+		client_id: "e2d3c81d-ab96-4009-a1d6-8e255109fd31",
+		client_secret: "0576385b-5a46-40de-8acf-7ab66900c22a",
+		token_endpoint_auth_method: "client_secret_basic", // "private_key_jwt",
+		id_token_signed_response_alg: "RS256",
+		request_object_signing_alg: "RS256",
+		redirect_uri: "https://invite.moneyhub.co.uk/api/callback",
+		response_type: "code id_token",
+		keys: [
+			{
+				kty: "RSA",
+				n: "tcDSe4tfn0phu5t2rhyJ-Y7CFfOod934pKEG2SMTzYCmJ33YAqo0Y9VrYRDpk_CL-cup_Gi-Pp8AnSyPWwbC0RFMDmpKlxQFZuqOy7eyzelqHtq3Io4aaYVe6ZIx3yJnOVg5lGsl7FsMmndx4xd8E5QGFTVsGZD56GRhjqXhbDGEGYDFVbyjhMX_0CIfxOrNnN-UztiuWNmBFX09RH_wzpQQ0diBb5smtlsf_5uowxQM5v8deLAPPkzGyp1Vl2aD053KFH6sOv1bU1QgmNqgxplY3Rlsg-VWVja4FIchqZVJpzXt93rUpQ_CpY76FVWPXLIxMqzJKTBbtXqxZB2DIQ",
+				e: "AQAB",
+				d: "HrDNOgxqXLEIONBDJZpvGANptaA72eXTFyWTzPW14dUv-WowIB8SkqsWo0DiWFddo5QnA5bCTTu3NFMyb9n_6qLDl4mOR92bHepMq4y89jVMdKJVG1IolpntUX6cykN6b738lxnSwQsM4UZ7JjAwhPPRZSJsuxJ2iK3upVJQct7Ovfx9sTCbQdZr3k23aYIdJLgZ-M89l_TgKD3BS8QUjV2_9t20VAYG5EXzGmJ2NB39QrUkXCsMWh9PxovjiytFl3czKd0Ga5yrWN6dmNVyn_MkkWrYNalnk2LjwnDVq4Cl50z822nU4dLrCTrqwD8DsXkDijJfvogiGEZ_39kHUw",
+				p: "3zeYAMnHOOHoGzbdFOIu-b8_h8h-3T0Hepx--sofhgKvDj7MeCpec4S8PkQY2nnZqyvIdT9rDbCeEjPOonMRk_lbVD8DsXynBr4l_uQ-DZaAMSaA0E8uBDQt72AAPRkgHsrz2tibduCeittfATU3zD825QJdaXigGMiWldh82jM",
+				q: "0HJJp9uWMPecJQHLLGxT1IpaTQMtPfS0E7-J-EdiEFYqE8JrU95kRU5DR0cvj2LMB3lMclz6LquQ-2bxErnDTEBZjjPzYSlBXIQzl3_SRG8y1QvphqtH8S0jjpOAp-zax-BARETIb0xpDiWt07hkFmfHlu0ZdsdLXmjJ3xdXQVs",
+				dp: "SpuZWcIXraKMYvQ-hulmzCEpSegwxx_L7SZ7prWCPdeNzVQeIZf_w9q81I8MQ5HwuC7FLLNKw-OhofHhAhk16eCxrwH06REB_tX1ezGsr_v60vLMoVOlzM_n_pd23PUV8FTjluVJaT2AoGbcZVn1UXZbkcXtlQA1erMo6eLXMFM",
+				dq: "TnPVWQICgyeOczc7mtqiqonv9rBNZNYmuJAMg4-KTw-_AnTYJFa9coBEPh2Cvvq2Q9HZfemUl-Amzxgtf5i-8oH9stHGtjjqysFPEaQgJXWcsiarm-33Q8Rzb4QAljNFHJlAVvF0Zr9hgtuXkuoBcZVZv2o5fUUBDuVtpTOJuaU",
+				qi: "qyJp3DfBDb3kr6KXUuRmntQX4GWSEfLEmy6sQ-RcsM5WcxDJn3ewCoUFAZBN4_Ki2TvYMUymVGngq8YbggaULk_dpavaCdZrVhP-0xWXifAw7v7DtNSeQ1y56zmKdsrQjTg5gPF7LYgB514wJQ7f_V4JGRgACS7McevVdsWJ4s4",
+				kid: "vTQbDStWdEYtiByztrupcgm-u4QQgYeoSbp1yj-yAPg",
+				use: "sig",
+				alg: "RS256",
+			},
+		],
+	},
 }
+
+// phoenix test config
+// const config = {
+// 	resourceServerUrl: "https://api-test.moneyhub.co.uk/v3",
+// 	identityServiceUrl: "https://identity-test.moneyhub.co.uk",
+// 	accountConnectUrl: "https://bank-chooser.moneyhub.co.uk/account-connect.js",
+// 	client: {
+// 		client_id: "6e1bb8b4-1f6c-4b4a-9cb0-060a2dde00ce",
+// 		client_secret: "d0078bc1-9aee-41c3-8573-25fa9396a1c7",
+// 		token_endpoint_auth_method: "private_key_jwt",
+// 		id_token_signed_response_alg: "RS256",
+// 		request_object_signing_alg: "RS256",
+// 		redirect_uri: "https://google.com",
+// 		response_type: "code id_token",
+// 		keys: [
+// 			{
+// 				kty: "RSA",
+// 				n: "2XT_S6gTvVCdTMBqQh_y1YVDBQMAqDvtgnd5OnH0uRFpB-wjSLeewtN6rMhPsamU43Cw6XJEj0tk1x3mNAsRyXSgCeIpd98GsFbGCJZ0yjtEgWk1QweFiPq3uUOmTzzbNSv0YbO-pBre1mbqM6PyIZp1rovn9oMT2UQw6CwyeOmudXliwSsnvKevpLRWTd6ufvFyCyf_Femw-p3S8-BOmnRXrsECKAa6yB5Phi7yo0E-Wga5DyeN1o8N8lA9FaCBH7P3kv9GU0ETx3Tmms4nfAqKfnc2IPOYsoG94aFtR1oC9Ro8A_zYVKKWIvXCHVR9ZEknUMjqe7B_JMS68Vmg_Q",
+// 				e: "AQAB",
+// 				d: "HEet593s60LvogqoBv92qjQRejZgwIBCrCPzfRlS1TqhaSlZkVxn5jhwjMXkL1u5hDakm0eECQqqC5vU01HZN1TWd1KVSASWLxqp2HYQrDg2-YmAJr50rFLGz-4vU8C7VVfpCUfB9D-WWVW7AYpBtAMNaOzC9vkm_Kt0nM0ap0SnOYMR_X92cGfFEKSPIyFQzthaGcUUS5vYEH7waImnuK8SulBApwhrwTXkg0Mb1mDXni5Gc68HtE7jKXBRc2BnBqvEpL7ey8sd3tsSzdqVtg7XfjoT6GZp_--Tb-YlHAPHtxfMW98U3CZhcKQuCCbCYjh4ilXaNzNN72BEKYYUoQ",
+// 				p: "-PKNFJ49J8sfzwbAoRWPoxQyHXJ7fnK-pF5pNPrLJT8WIjh1usv75MlyiOZwXxQzNrPZW-Tpi9xnF_en5ER-RIk3C3xV2SQyMxiUlzuuyOBReqzKc3P4ZxBPDx9cJ-nfmJT4_PLsf62eYGsStJcdgnvvWd1_tWW9tG4xL914TOU",
+// 				q: "354RLL-8aWAHP16Odj42W0djx_4SO9Va0SDBhUTNbUn7rVsNOYETMUGh9ljetls4veENPG01dzqgXNBaGwLg3YzxTcBaFYw7ysmUidrFRgTsd67JFKkgfK8YqPKU5aoasp3mNhh_6NHuYr3-6AdoUFToF45OkTxZbAxS-pvoWjk",
+// 				dp: "IZ4PcyNTOtZxOzG8PYR92xXVFqjpCFBScjvVlTPwztzQDlr1ev4ky-ZwMxB7SDugFtj-lyw4ZYyj11a4M1kUfAjTiBeIOERtCv1cw3dpyPKRzjEbPbABcVmAc5hWh4VLjn0_ilj7mtpFMtwCsKRfdclqrwX8QvC0R3NB7SbJIgk",
+// 				dq: "i7NliW5TmAVtIbLCD674KHhmJvhcjdLRxNrQ66A7Mm7I89lxXp57zgbx10RYBtbgkQd7TGfxwgX3T2S_FibrMp4t1mQ4I0QTyrG6wZDSM9c5n9-rMeQjLqH5Jvs9-GkX-sTYoK0Xo-0bH8cQ7AZMrfsNcEHwZZ2tQ-pDINusAkk",
+// 				qi: "yOASRctdA89TRIEr3ArmjT4Wp43vgYs_DKiX1Z53UA8bJ-_cPPQqNuYK34ZLfSE2O_rJuvkoez4ovycZi18hykcHrIEqQQhtSMnCX8iwpDeZJDHBvMW0-O-CjMLDNysbxA-ezj7q42q6kKDDr13j75lCzQYDXsRMPpke3ipt_Ak",
+// 				kid: "JFqYxaLmjUZOAkhKXj8KWkcBZvJCsXtFz2tGYGpqUc8",
+// 				use: "sig",
+// 				alg: "RS256",
+// 			},
+// 		],
+// 	},
+// }
 
 module.exports = config

--- a/examples/jwks/create-jwks.js
+++ b/examples/jwks/create-jwks.js
@@ -1,6 +1,7 @@
 // 1st step is to create jwks with - node examples/jwks/create-jwks.js --alg RS256 --key-use sig --key-size 2048
 // paste public keys in admin portal (under the client) and private keys in the api client configuration - moneyhub-api-client/examples/config.js
 // node examples/token/get-client-credential-token.js -s "scim_user:read”
+// npx ts-node examples/token/get-client-credential-token.js -u {userId of user} -s widget_authentication
 
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")

--- a/examples/jwks/create-jwks.js
+++ b/examples/jwks/create-jwks.js
@@ -1,5 +1,7 @@
 // 1st step is to create jwks with - node examples/jwks/create-jwks.js --alg RS256 --key-use sig --key-size 2048
 // paste public keys in admin portal (under the client) and private keys in the api client configuration - moneyhub-api-client/examples/config.js
+// node examples/token/get-client-credential-token.js -s "scim_user:read”
+
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
 const jose = require("jose")

--- a/examples/jwks/create-jwks.js
+++ b/examples/jwks/create-jwks.js
@@ -1,17 +1,19 @@
+// 1st step is to create jwks with - node examples/jwks/create-jwks.js --alg RS256 --key-use sig --key-size 2048
+// paste public keys in admin portal (under the client) and private keys in the api client configuration - moneyhub-api-client/examples/config.js
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
 const jose = require("jose")
 
 const optionDefinitions = [
-  {name: "key-alg", type: String},
-  {name: "key-use", type: String},
-  {name: "key-size", type: Number},
-  {name: "alg", type: String},
+	{name: "key-alg", type: String},
+	{name: "key-use", type: String},
+	{name: "key-size", type: Number},
+	{name: "alg", type: String},
 ]
 
 const usage = commandLineUsage({
-  header: "Options",
-  optionList: optionDefinitions,
+	header: "Options",
+	optionList: optionDefinitions,
 })
 const options = commandLineArgs(optionDefinitions)
 
@@ -19,46 +21,44 @@ console.log(usage)
 
 // eslint-disable-next-line max-statements
 const start = async () => {
-  try {
-    const keySize = options["key-size"] || 2048
-    const keyUse = options["key-use"] || "sig"
-    const alg = options.alg || "RS256"
+	try {
+		const keySize = options["key-size"] || 2048
+		const keyUse = options["key-use"] || "sig"
+		const alg = options.alg || "RS256"
 
-    const {publicKey, privateKey} = await jose.generateKeyPair(alg, {
-      extractable: true,
-      modulusLength: keySize,
-    })
+		const {publicKey, privateKey} = await jose.generateKeyPair(alg, {
+			extractable: true,
+			modulusLength: keySize,
+		})
 
-    const exportedPrivateJWT = await jose.exportJWK(privateKey)
-    const exportedPublicJWT = await jose.exportJWK(publicKey)
+		const exportedPrivateJWT = await jose.exportJWK(privateKey)
+		const exportedPublicJWT = await jose.exportJWK(publicKey)
 
-    const kid = await jose.calculateJwkThumbprint(exportedPublicJWT)
+		const kid = await jose.calculateJwkThumbprint(exportedPublicJWT)
 
-    const privateJWT = {...exportedPrivateJWT, kid, use: keyUse, alg}
-    const publicJWT = {...exportedPublicJWT, kid, use: keyUse, alg}
+		const privateJWT = {...exportedPrivateJWT, kid, use: keyUse, alg}
+		const publicJWT = {...exportedPublicJWT, kid, use: keyUse, alg}
 
-    const publicJWKS = {
-      keys: [publicJWT]
-    }
+		const publicJWKS = {
+			keys: [publicJWT],
+		}
 
-    const privateJWKS = {
-      keys: [privateJWT]
-    }
+		const privateJWKS = {
+			keys: [privateJWT],
+		}
 
-    console.log("Public keys")
-    console.log(
-      "This can be used as the JWKS in your API client configuration in the Moneyhub Admin portal"
-    )
-    console.log(JSON.stringify(publicJWKS, null, 4))
-    console.log("\n\nPrivate keys")
-    console.log(
-      "This can be used as the keys value when configuring the moneyhub api client"
-    )
-    console.log(JSON.stringify(privateJWKS, null, 4))
-  } catch (e) {
-    console.log(e)
-    console.error(e.response.body)
-  }
+		console.log("Public keys")
+		console.log(
+			"This can be used as the JWKS in your API client configuration in the Moneyhub Admin portal",
+		)
+		console.log(JSON.stringify(publicJWKS, null, 4))
+		console.log("\n\nPrivate keys")
+		console.log("This can be used as the keys value when configuring the moneyhub api client")
+		console.log(JSON.stringify(privateJWKS, null, 4))
+	} catch (e) {
+		console.log(e)
+		console.error(e.response.body)
+	}
 }
 
 start()

--- a/examples/token/create-jwt-bearer-grant-token.js
+++ b/examples/token/create-jwt-bearer-grant-token.js
@@ -1,15 +1,15 @@
-const {Moneyhub} = require("../../src/index")
+const {Moneyhub} = require("../../dist/index")
 const config = require("../config")
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
 
 const optionDefinitions = [
-  {name: "subject", alias: "s", type: String, description: "required (can be userId or clientId)"},
+	{name: "subject", alias: "s", type: String, description: "required (can be userId or clientId)"},
 ]
 
 const usage = commandLineUsage({
-  header: "Options",
-  optionList: optionDefinitions,
+	header: "Options",
+	optionList: optionDefinitions,
 })
 
 console.log(usage)
@@ -19,15 +19,15 @@ const options = commandLineArgs(optionDefinitions)
 if (!options.subject) throw new Error("subject (userId or clientId) needs to be provided")
 
 const start = async () => {
-  try {
-    const moneyhub = await Moneyhub(config)
+	try {
+		const moneyhub = await Moneyhub(config)
 
-    const data = await moneyhub.createJWTBearerGrantToken(options.subject)
-    console.log(JSON.stringify(data, null, 2))
-  } catch (e) {
-    console.log(e)
-    console.error(e.response.body)
-  }
+		const data = await moneyhub.createJWTBearerGrantToken(options.subject)
+		console.log(JSON.stringify(data, null, 2))
+	} catch (e) {
+		console.log(e)
+		console.error(e.response.body)
+	}
 }
 
 start()

--- a/examples/token/get-access-token-client-credentials.js
+++ b/examples/token/get-access-token-client-credentials.js
@@ -1,0 +1,79 @@
+const {Moneyhub} = require("../../dist/index")
+const config = require("../config")
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+	{name: "subject", alias: "s", type: String, description: "required (can be userId or clientId)"},
+	{name: "scope", alias: "c", defaultValue: "scim_user:write", type: String, description: "required scopes"},
+]
+
+const usage = commandLineUsage({
+	header: "Options",
+	optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+if (!options.subject) throw new Error("subject (userId or clientId) needs to be provided")
+
+const start = async () => {
+	try {
+		const moneyhub = await Moneyhub(config)
+
+		console.log("=== Using Client Credentials Grant to Get Access Token ===")
+		console.log("This uses your private_key_jwt authentication automatically")
+		console.log("")
+		
+		// Use client credentials grant with JWT authentication
+		const tokenResponse = await moneyhub.getClientCredentialTokens({
+			scope: options.scope,
+			sub: options.subject, // Use your client ID as the subject
+		})
+		
+		console.log("✅ Access Token Response:")
+		console.log(JSON.stringify(tokenResponse, null, 2))
+		console.log("")
+		
+		console.log("=== Use this Access Token in Postman ===")
+		console.log("Copy this access token:")
+		console.log(tokenResponse.access_token)
+		console.log("")
+		console.log("In Postman:")
+		console.log("1. Set Authorization header to: Bearer " + tokenResponse.access_token)
+		console.log("2. Set Content-Type header to: application/json")
+		console.log("3. Make POST request to: https://identity-test.moneyhub.co.uk/scim/users")
+		console.log("")
+		console.log("Request Body Example:")
+		console.log(JSON.stringify({
+			"externalId": "your-external-user-id",
+			"name": {
+				"givenName": "John",
+				"familyName": "Doe"
+			},
+			"emails": [
+				{
+					"value": "john.doe@example.com",
+					"primary": true
+				}
+			]
+		}, null, 2))
+		
+	} catch (e) {
+		console.error("❌ Error:", e.message)
+		if (e.response && e.response.body) {
+			console.error("Response body:", e.response.body)
+		}
+		
+		if (e.error === 'invalid_scope') {
+			console.log("")
+			console.log("💡 This error means the scope is not allowed for your client.")
+			console.log("Try with a different scope that your client has permission for.")
+		}
+	}
+}
+
+start()
+

--- a/examples/token/get-access-token-for-scim.js
+++ b/examples/token/get-access-token-for-scim.js
@@ -1,0 +1,62 @@
+const {Moneyhub} = require("../../dist/index")
+const config = require("../config")
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+	{name: "subject", alias: "s", type: String, description: "required (can be userId or clientId)"},
+	{name: "scope", alias: "c", defaultValue: "scim_user:write", type: String, description: "required scopes"},
+]
+
+const usage = commandLineUsage({
+	header: "Options",
+	optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+if (!options.subject) throw new Error("subject (userId or clientId) needs to be provided")
+
+const start = async () => {
+	try {
+		const moneyhub = await Moneyhub(config)
+
+		console.log("=== Step 1: Creating JWT Assertion Token ===")
+		const jwtAssertion = await moneyhub.createJWTBearerGrantToken(options.subject)
+		console.log("JWT Assertion Token:")
+		console.log(jwtAssertion)
+		console.log("")
+
+		console.log("=== Step 2: Using JWT Assertion to Get Access Token ===")
+		console.log("Making request to token endpoint...")
+		
+		// Use the JWT assertion to get an access token
+		const tokenResponse = await moneyhub.getJWTBearerToken({
+			scope: options.scope,
+			sub: options.subject,
+		})
+		
+		console.log("✅ Access Token Response:")
+		console.log(JSON.stringify(tokenResponse, null, 2))
+		console.log("")
+		
+		console.log("=== Step 3: Use this Access Token in Postman ===")
+		console.log("Copy this access token:")
+		console.log(tokenResponse.access_token)
+		console.log("")
+		console.log("In Postman:")
+		console.log("1. Set Authorization header to: Bearer " + tokenResponse.access_token)
+		console.log("2. Set Content-Type header to: application/json")
+		console.log("3. Make POST request to: https://identity-test.moneyhub.co.uk/scim/users")
+		
+	} catch (e) {
+		console.error("❌ Error:", e.message)
+		if (e.response && e.response.body) {
+			console.error("Response body:", e.response.body)
+		}
+	}
+}
+
+start()

--- a/examples/token/get-client-credential-token-with-jwt.js
+++ b/examples/token/get-client-credential-token-with-jwt.js
@@ -1,0 +1,72 @@
+const {Moneyhub} = require("../../dist/index")
+const config = require("../config")
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+	{name: "userId", alias: "u", type: String, description: "User ID (optional - omit for client-only token)"},
+	{name: "scopes", alias: "s", defaultValue: "widget_authentication", type: String, description: "required scopes"},
+]
+
+const usage = commandLineUsage({
+	header: "Options",
+	optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+const start = async () => {
+	try {
+		const moneyhub = await Moneyhub(config)
+
+		console.log("=== JWT Authentication with Client Credentials Grant ===")
+		console.log("")
+		console.log("Your configuration uses 'private_key_jwt' authentication.")
+		console.log("The openid-client library automatically creates JWT assertions with these claims:")
+		console.log("")
+		console.log("JWT Claims (automatically generated):")
+		console.log(`- iss (issuer): ${config.client.client_id}`)
+		console.log(`- sub (subject): ${options.userId || 'client_id (for client-only tokens)'}`)
+		console.log(`- aud (audience): ${config.identityServiceUrl}/oidc/token`)
+		console.log(`- jti (JWT ID): auto-generated unique identifier`)
+		console.log(`- iat (issued at): current timestamp`)
+		console.log(`- exp (expiration): 5 minutes from now`)
+		console.log("")
+		console.log("Request parameters:")
+		console.log(`- grant_type: client_credentials`)
+		console.log(`- scope: ${options.scopes}`)
+		if (options.userId) {
+			console.log(`- sub: ${options.userId}`)
+		}
+		console.log("")
+
+		const data = await moneyhub.getClientCredentialTokens({
+			scope: options.scopes,
+			sub: options.userId, // Optional - omit for client-only tokens
+		})
+		
+		console.log("✅ Success! Token Response:")
+		console.log(JSON.stringify(data, null, 2))
+	} catch (e) {
+		console.error("❌ Error:", e.message)
+		if (e.response && e.response.body) {
+			console.error("Response body:", e.response.body)
+		}
+		
+		if (e.error === 'invalid_subject') {
+			console.log("")
+			console.log("💡 This error means:")
+			console.log("1. ✅ JWT authentication is working correctly")
+			console.log("2. ✅ Your private key is being used to sign the JWT")
+			console.log("3. ❌ The user ID doesn't exist in the system")
+			console.log("")
+			console.log("Try running without a user ID for a client-only token:")
+			console.log(`node examples/token/get-client-credential-token.js -s ${options.scopes}`)
+		}
+	}
+}
+
+start()
+

--- a/examples/token/get-client-credential-token-with-user.js
+++ b/examples/token/get-client-credential-token-with-user.js
@@ -1,0 +1,83 @@
+const {Moneyhub} = require("../../dist/index")
+const config = require("../config")
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+
+const optionDefinitions = [
+	{name: "userId", alias: "u", type: String, description: "User ID (optional - will create one if not provided)"},
+	{name: "scopes", alias: "s", defaultValue: "widget_authentication", type: String, description: "required scopes"},
+	{name: "createUser", alias: "c", type: Boolean, description: "Create a new user first"},
+]
+
+const usage = commandLineUsage({
+	header: "Options",
+	optionList: optionDefinitions,
+})
+
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+const start = async () => {
+	try {
+		const moneyhub = await Moneyhub(config)
+
+		let userId = options.userId
+
+		// Create a user if requested or if no user ID provided
+		if (options.createUser || !userId) {
+			console.log("=== Creating a new user ===")
+			const newUser = await moneyhub.registerUser({
+				clientUserId: `test-user-${Date.now()}`,
+			})
+			userId = newUser.userId
+			console.log(`✅ Created user with ID: ${userId}`)
+			console.log("")
+		}
+
+		console.log("=== JWT Authentication with Client Credentials Grant ===")
+		console.log("")
+		console.log("Your configuration uses 'private_key_jwt' authentication.")
+		console.log("The openid-client library automatically creates JWT assertions with these claims:")
+		console.log("")
+		console.log("JWT Claims (automatically generated):")
+		console.log(`- iss (issuer): ${config.client.client_id}`)
+		console.log(`- sub (subject): ${userId}`)
+		console.log(`- aud (audience): ${config.identityServiceUrl}/oidc/token`)
+		console.log(`- jti (JWT ID): auto-generated unique identifier`)
+		console.log(`- iat (issued at): current timestamp`)
+		console.log(`- exp (expiration): 5 minutes from now`)
+		console.log("")
+		console.log("Request parameters:")
+		console.log(`- grant_type: client_credentials`)
+		console.log(`- scope: ${options.scopes}`)
+		console.log(`- sub: ${userId}`)
+		console.log("")
+
+		const data = await moneyhub.getClientCredentialTokens({
+			scope: options.scopes,
+			sub: userId,
+		})
+		
+		console.log("✅ Success! Token Response:")
+		console.log(JSON.stringify(data, null, 2))
+	} catch (e) {
+		console.error("❌ Error:", e.message)
+		if (e.response && e.response.body) {
+			console.error("Response body:", e.response.body)
+		}
+		
+		if (e.error === 'invalid_subject') {
+			console.log("")
+			console.log("💡 This error means:")
+			console.log("1. ✅ JWT authentication is working correctly")
+			console.log("2. ✅ Your private key is being used to sign the JWT")
+			console.log("3. ❌ The user ID doesn't exist in the system")
+			console.log("")
+			console.log("Try creating a new user first:")
+			console.log(`node examples/token/get-client-credential-token-with-jwt.js -c -s ${options.scopes}`)
+		}
+	}
+}
+
+start()

--- a/examples/token/get-client-credential-token.js
+++ b/examples/token/get-client-credential-token.js
@@ -1,4 +1,4 @@
-const {Moneyhub} = require("../../src/index")
+const {Moneyhub} = require("../../dist/index")
 const config = require("../config")
 const {DEFAULT_DATA_SCOPES_USE_CASE_2} = require("../constants")
 const commandLineArgs = require("command-line-args")

--- a/examples/token/get-jwt-bearer-token.js
+++ b/examples/token/get-jwt-bearer-token.js
@@ -1,40 +1,60 @@
-const {Moneyhub} = require("../../src/index")
+const {Moneyhub} = require("../../dist/index")
 const config = require("../config")
-const {DEFAULT_DATA_SCOPES_USE_CASE_2} = require("../constants")
 const commandLineArgs = require("command-line-args")
 const commandLineUsage = require("command-line-usage")
 
 const optionDefinitions = [
-  {name: "userId", alias: "u", type: String, description: "required"},
-  {name: "scopes", alias: "s", defaultValue: DEFAULT_DATA_SCOPES_USE_CASE_2, type: String},
+	{name: "userId", alias: "u", type: String, description: "required - User ID or API user ID"},
+	{
+		name: "scopes",
+		alias: "s",
+		defaultValue: "widget_authentication",
+		type: String,
+		description: "required scopes",
+	},
 ]
 
-const usage = commandLineUsage(
-  {
-    header: "Options",
-    optionList: optionDefinitions,
-  }
-)
+const usage = commandLineUsage({
+	header: "Options",
+	optionList: optionDefinitions,
+})
 
 console.log(usage)
 
 const options = commandLineArgs(optionDefinitions)
 
-if (!options.userId) throw new Error("userId needs to be provided")
+if (!options.userId) {
+	console.error("Error: userId (-u) is required")
+	process.exit(1)
+}
 
 const start = async () => {
-  try {
-    const moneyhub = await Moneyhub(config)
+	try {
+		const moneyhub = await Moneyhub(config)
 
-    const data = await moneyhub.getJWTBearerToken({
-      scope: options.scopes,
-      sub: options.userId,
-    })
-    console.log(JSON.stringify(data, null, 2))
-  } catch (e) {
-    console.log(e)
-    console.error(e.response.body)
-  }
+		console.log("Creating JWT Bearer token with the following claims:")
+		console.log(`- iss (issuer): ${config.client.client_id}`)
+		console.log(`- sub (subject): ${options.userId}`)
+		console.log(`- aud (audience): ${config.identityServiceUrl}/oidc/token`)
+		console.log(`- jti (JWT ID): auto-generated unique identifier`)
+		console.log(`- iat (issued at): current timestamp`)
+		console.log(`- exp (expiration): 10 minutes from now`)
+		console.log(`- scope: ${options.scopes}`)
+		console.log("")
+
+		const data = await moneyhub.getJWTBearerToken({
+			scope: options.scopes,
+			sub: options.userId,
+		})
+
+		console.log("JWT Bearer Token Response:")
+		console.log(JSON.stringify(data, null, 2))
+	} catch (e) {
+		console.error("Error:", e.message)
+		if (e.response && e.response.body) {
+			console.error("Response body:", e.response.body)
+		}
+	}
 }
 
 start()


### PR DESCRIPTION
Never going to be merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> The diff commits live client secrets and a full private signing key in `examples/config.js`, which is a serious credential exposure if this branch is ever pushed or merged.
> 
> **Overview**
> Replaces the generic `examples/config.js` placeholder with an active **Phoenix local** setup (nip.io API gateway and identity URLs, real `client_id`/`client_secret`, embedded RSA private JWK, and OIDC tweaks like `response_type: "code id_token"`). The previous production-style template and an alternate local/test block are kept as **commented** snippets for quick switching.
> 
> Token-related examples now import from **`../../dist/index`** instead of `src`, and `create-jwks.js` gains top-of-file workflow notes. Several **new** CLI scripts walk through client-credentials and JWT-bearer flows (`widget_authentication`, SCIM scopes), with verbose logging and Postman-oriented output; existing scripts get similar claim/error messaging and default scope changes (e.g. `widget_authentication` on JWT bearer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ecb8c0f4da854a20455adbaad286eecd4aca6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->