### PR TITLE
Fix caas response metas

### DIFF
--- a/src/__tests__/caas/get-counterparties.ts
+++ b/src/__tests__/caas/get-counterparties.ts
@@ -49,6 +49,12 @@ describe("GET /counterparties", function() {
       )
     })
 
+    it("response meta uses standard ResponseMeta shape", function() {
+      expect(response.meta).to.exist
+      expect(response.meta).to.have.property("correlationId").that.is.a("string")
+      expect(response.meta).not.to.have.property("errorTransactionIds")
+    })
+
     it("response contains the seeded counterparties", function() {
       const returnedIds = response.data.map((c) => c.l3CounterpartyId)
 

--- a/src/__tests__/caas/post-transactions-enrich.ts
+++ b/src/__tests__/caas/post-transactions-enrich.ts
@@ -85,6 +85,15 @@ describe("POST /transactions/enrich", function() {
       assertMatchesOpenApi(validateResponse, response, "Response")
     })
 
+    it("response meta uses TransactionsEnrichResponseMeta shape", function() {
+      expect(response.meta).to.exist
+      expect(response.meta).to.have.property("correlationId").that.is.a("string")
+
+      if (response.meta.errorTransactionIds !== undefined) {
+        expect(response.meta.errorTransactionIds).to.be.an("array")
+      }
+    })
+
     it("response contains enriched transactions", function() {
       expect(response.data).to.be.an("array").with.length.above(0)
     })

--- a/src/__tests__/caas/response-meta.ts
+++ b/src/__tests__/caas/response-meta.ts
@@ -1,0 +1,38 @@
+import {
+  fetchOpenApiSpec,
+} from "./openapi"
+import {assertTypeMatchesOpenApi} from "./typescript-validator"
+
+const TYPES_FILE = "../../../requests/caas/types/response-meta.ts"
+
+describe("CaaS response meta types match OpenAPI schemas", function() {
+  this.timeout(30000)
+
+  let spec: Awaited<ReturnType<typeof fetchOpenApiSpec>>
+
+  before(async function() {
+    if (this.skipOpenApiTests) {
+      this.skip()
+    }
+
+    spec = await fetchOpenApiSpec(this.config.caas.openapiUrl)
+  })
+
+  it("CaasResponseMeta matches OpenAPI ResponseMeta definition", function() {
+    assertTypeMatchesOpenApi({
+      tsType: "CaasResponseMeta",
+      tsFile: TYPES_FILE,
+      openApiSchemaName: "ResponseMeta",
+      spec,
+    })
+  })
+
+  it("CaasTransactionsEnrichResponseMeta matches OpenAPI TransactionsEnrichResponseMeta definition", function() {
+    assertTypeMatchesOpenApi({
+      tsType: "CaasTransactionsEnrichResponseMeta",
+      tsFile: TYPES_FILE,
+      openApiSchemaName: "TransactionsEnrichResponseMeta",
+      spec,
+    })
+  })
+})

--- a/src/__tests__/caas/typescript-validator/checks.ts
+++ b/src/__tests__/caas/typescript-validator/checks.ts
@@ -320,8 +320,9 @@ export function findSchemaErrors({
     openApi: openApiDefinitions,
   }
 
+  const resolvedTs = resolveToObject(tsSchema, definitions.ts)
   const resolvedOpenApi = resolveToObject(openApiSchema, openApiDefinitions)
-  const ts = propsFromSchema(tsSchema)
+  const ts = propsFromSchema(resolvedTs)
   const openApi = propsFromSchema(resolvedOpenApi)
 
   const allFields = collectFieldPairs({

--- a/src/requests/caas/types/regular-transactions.ts
+++ b/src/requests/caas/types/regular-transactions.ts
@@ -25,7 +25,7 @@ export interface CaasRegularTransactionLine {
   cleanedDescription: string
   txCode?: string | null
   cardPresent?: boolean | null
-  analysisCategory?: string | null
+  l3CounterpartyCategory?: string | null
 }
 
 export interface CaasRegularTransaction {
@@ -37,8 +37,6 @@ export interface CaasRegularTransaction {
   frequency: CaasRegularTransactionFrequency
   description: string
   cleanedDescription: string
-  matchMethod: string
-  stitched: boolean
   numTxMatchedInSeries: number
   gapLengthInFreqUnits: number
   dateAnomaliesCount: number
@@ -47,16 +45,14 @@ export interface CaasRegularTransaction {
   predictedDate: string
   predictedDateEarliest?: string | null
   predictedDateLatest?: string | null
-  predictedDateMethod: string
   predictedTxLateOrNotDetected?: boolean | null
   predictedAmount: number | null
   predictedAmountLower?: number | null
   predictedAmountUpper?: number | null
-  predictedAmountMethod: string
   currency?: string | null
   counterpartyId?: string | null
-  predictedCategoryId: string
-  analysisCategory?: string | null
+  l3CounterpartyCategory?: string | null
+  predictedCategoryId: string | null
   transactions: CaasRegularTransactionLine[]
 }
 

--- a/src/requests/caas/types/response-meta.ts
+++ b/src/requests/caas/types/response-meta.ts
@@ -1,0 +1,8 @@
+export interface CaasResponseMeta {
+  correlationId: string
+  count?: number
+}
+
+export interface CaasTransactionsEnrichResponseMeta extends CaasResponseMeta {
+  errorTransactionIds?: string[]
+}

--- a/src/requests/caas/types/transactions.ts
+++ b/src/requests/caas/types/transactions.ts
@@ -6,14 +6,12 @@ import type {
   CaasL2CategoryId,
   CaasL2CategoryName,
 } from "./categories"
+import type {CaasTransactionsEnrichResponseMeta} from "./response-meta"
 import type {CaasTransactionSplit} from "./transaction-splits"
 
 export interface CaasEnrichTransactionsResponse {
   data: CaasTransaction[]
-  meta: {
-    errorTransactionIds: string[]
-    correlationId: string
-  }
+  meta: CaasTransactionsEnrichResponseMeta
 }
 
 export type CaasAccountType =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type and test alignment with OpenAPI; regular-transaction field removals and renames may break compile-time consumers of those interfaces but do not change runtime API behavior in this diff.
> 
> **Overview**
> Aligns CaaS client types and tests with the OpenAPI spec for **response `meta`** and **regular transactions**.
> 
> Introduces shared **`CaasResponseMeta`** / **`CaasTransactionsEnrichResponseMeta`** and wires enrich responses to use them instead of an inline meta object where **`errorTransactionIds`** is now **optional** (not always required). Adds OpenAPI parity tests for those meta types plus integration checks that list endpoints use standard **`ResponseMeta`** (no **`errorTransactionIds`**) while enrich allows the enrich-specific meta shape.
> 
> **Regular transaction** types are updated to match the spec: **`analysisCategory`** → **`l3CounterpartyCategory`**, **`predictedCategoryId`** is **nullable**, and several fields that are not in OpenAPI (**`matchMethod`**, **`stitched`**, prediction method strings, etc.) are removed from the TS interfaces.
> 
> The TypeScript↔OpenAPI validator now **resolves the TS schema to an object** before comparing properties, so extended interfaces (e.g. enrich meta) compare correctly against OpenAPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a0eef32b87d0c1d7cffa922a94af9d3f3041e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->