### PR TITLE
Add post account balance

### DIFF
--- a/examples/accounts/post-account-balance.js
+++ b/examples/accounts/post-account-balance.js
@@ -1,0 +1,40 @@
+const commandLineArgs = require("command-line-args")
+const commandLineUsage = require("command-line-usage")
+const {Moneyhub} = require("../../src/index")
+const config = require("../config")
+
+const optionDefinitions = [
+  {name: "accountId", alias: "a", type: String, description: "required"},
+  {name: "userId", alias: "u", type: String, description: "required"},
+  {name: "value", alias: "v", type: String, description: "required"},
+  {name: "date", alias: "d", type: String, description: "required"},
+]
+
+const usage = commandLineUsage({
+  header: "Options",
+  optionList: optionDefinitions,
+})
+console.log(usage)
+
+const options = commandLineArgs(optionDefinitions)
+
+const start = async () => {
+  try {
+    const moneyhub = await Moneyhub(config)
+
+    const result = await moneyhub.postAccountBalance({
+      userId: options.userId,
+      accountId: options.accountId,
+      balance: {
+        amount: {value: Number(options.value)},
+        date: options.date
+      }
+    })
+    console.log(JSON.stringify(result, null, 2))
+  } catch (e) {
+    console.log(e)
+    console.error(e.response.body)
+  }
+}
+
+start()

--- a/src/__tests__/accounts.ts
+++ b/src/__tests__/accounts.ts
@@ -2,6 +2,7 @@
 import {expect} from "chai"
 import {expectTypeOf} from "expect-type"
 import {AccountBalancePost, AccountPatch} from "src/schema/account"
+import {Balance} from "src/schema/balance"
 
 import {Moneyhub, MoneyhubInstance, Accounts, Counterparties, Holdings, Transactions} from ".."
 
@@ -84,6 +85,18 @@ describe("Accounts", function() {
     const {data: account} = await moneyhub.getAccount({userId, accountId})
     expect(account.id).to.eql(accountId)
     expectTypeOf<Accounts.Account>(account)
+  })
+
+  it("post account balance", async function() {
+    const {data: balance} = await moneyhub.postAccountBalance({
+      userId,
+      accountId,
+      balance: {
+        amount: {value: 1},
+        date: "2026-01-01",
+      }})
+    expect(balance.amount.value).to.eql(1)
+    expectTypeOf<Balance>(balance)
   })
 
   it("get counterparties", async function() {

--- a/src/requests/accounts.ts
+++ b/src/requests/accounts.ts
@@ -66,6 +66,17 @@ export default ({
         options,
       }),
 
+    postAccountBalance: async ({userId, accountId, balance}, options) =>
+      request(`${resourceServerUrl}/accounts/${accountId}/balances`, {
+        method: "POST",
+        cc: {
+          scope: "accounts:read accounts:write:all",
+          sub: userId,
+        },
+        options,
+        body: balance,
+      }),
+
     getAccountWithDetails: async ({userId, accountId}, options) =>
       request(`${resourceServerUrl}/accounts/${accountId}`, {
         cc: {

--- a/src/requests/types/accounts.ts
+++ b/src/requests/types/accounts.ts
@@ -1,6 +1,6 @@
 import type {ApiResponse, ExtraOptions, SearchParams} from "../../request"
 import type {Account, AccountWithDetails, AccountPost, AccountBalancePost, AccountPatch} from "../../schema/account"
-import type {Balance} from "../../schema/balance"
+import type {Balance, BalancePost} from "../../schema/balance"
 import type {Counterparty} from "../../schema/counterparty"
 import type {HoldingWithMatches, HoldingWithMatchesAndHistory, HoldingsValuation} from "../../schema/holding"
 import type {RecurringTransactionEstimate} from "../../schema/transaction"
@@ -30,6 +30,15 @@ export interface AccountsRequests {
     userId?: string
     accountId: string
   }, options?: ExtraOptions) => Promise<ApiResponse<Balance[]>>
+  postAccountBalance: ({
+    userId,
+    accountId,
+    balance,
+  }: {
+    userId?: string
+    accountId: string
+    balance: BalancePost
+  }, options?: ExtraOptions) => Promise<ApiResponse<Balance>>
   getAccountWithDetails: ({
     userId,
     accountId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small SDK surface addition over an existing balances POST pattern; writes account balance data but mirrors established `addAccountBalance` behavior with stricter read scopes on the new method.
> 
> **Overview**
> Adds **`postAccountBalance`** so callers can POST a balance to `/accounts/{accountId}/balances` using the **`BalancePost`** payload and **`Balance`** response types (aligned with **`getAccountBalances`**).
> 
> The request layer wires a POST with **`accounts:read accounts:write:all`**, types are declared on **`AccountsRequests`**, and coverage includes an integration test plus a CLI example under **`examples/accounts/post-account-balance.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f720033a53c93256ef409df20ebe93f1fee1502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->