### PR TITLE
Drop live integration tests from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@
 #
 # Only moneyhub/moneyhub-api-client may publish (synced private mirrors skip this workflow).
 #
-# Tests run on the static-IP runner (API allowlists). Publish must use a
+# Live integration / CaaS tests are not run here: they need allowlisted egress IPs and
+# private secrets, and run in the private synced repo instead. Publish uses a
 # GitHub-hosted runner — npm provenance does not support self-hosted runners.
 name: Publish to npm
 
@@ -56,14 +57,13 @@ jobs:
             echo "skip=false" >> "${GITHUB_OUTPUT}"
           fi
 
-  test:
-    name: Integration tests
+  verify:
+    name: Lint and build
     needs: should-publish
     if: ${{ github.repository == 'moneyhub/moneyhub-api-client' && needs.should-publish.outputs.skip != 'true' }}
-    runs-on: linux-x64-static-ip-2core-8gb
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write # moneyhub/run-and-report-tests (Check Runs API)
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,18 +79,14 @@ jobs:
         run: npm audit signatures
       - name: Rebuild native modules and run prepare
         run: npm rebuild && npm run prepare --if-present
-      - name: Run and Report Unit Tests
-        uses: moneyhub/run-and-report-tests@667f7c926eea73ac99e8e3e9f02fa7e58dc5ee89 # v1
-        with:
-          test-script: test-ci
-          report-path: test-reports/report.xml
-          name: Integration
-        env:
-          NODE_CONFIG: ${{ secrets.TEST_CONFIG }}
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
 
   publish:
     name: Build and publish
-    needs: [should-publish, test]
+    needs: [should-publish, verify]
     if: ${{ github.repository == 'moneyhub/moneyhub-api-client' && needs.should-publish.outputs.skip != 'true' }}
     runs-on: ubuntu-latest
     permissions:

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ const {Moneyhub} = require("@mft/moneyhub-api-client")
 
 ## Publishing (maintainers)
 
-Official releases are published to npm by **GitHub Actions** when a [GitHub Release](https://github.com/moneyhub/moneyhub-api-client/releases) is published (see `.github/workflows/publish.yml`). Do not rely on publishing from a developer machine.
+Official releases are published to npm by **GitHub Actions** when a [GitHub Release](https://github.com/moneyhub/moneyhub-api-client/releases) is published (see `.github/workflows/publish.yml`). The publish workflow runs lint and build on GitHub-hosted runners; live integration tests run in the private synced repository (allowlisted IPs / secrets). Do not rely on publishing from a developer machine.
 
 The `prepublishOnly` lifecycle script runs **`scripts/assert-github-actions-publish.js`** before the build. It exits with an error unless `GITHUB_ACTIONS` is set (as it is in GitHub Actions), so a normal local `npm publish` is blocked. That reduces accidental publishes; it is **not** a security boundary on its own—npm access control and trusted publishing still matter.
 


### PR DESCRIPTION
## Summary
- Remove the static-IP integration job (and `moneyhub/run-and-report-tests`) from `.github/workflows/publish.yml`
- Replace it with lint + build on `ubuntu-latest` so release publish no longer depends on allowlisted egress or org runner access
- Live integration / CaaS coverage remains in the private synced repo

## Why
The public repo cannot pick up `linux-x64-static-ip-2core-8gb`, and moving the action to `mh-internal/` does not fix the IP allowlist problem for GitHub-hosted runners.

## Test plan
- [ ] Merge and re-run / re-publish the `v6.100.0` release (or create a new release if needed)
- [ ] Confirm Publish workflow: Preflight → Lint and build → Build and publish
- [ ] Confirm private repo still runs integration tests on sync/push


Made with [Cursor](https://cursor.com)