### PR TITLE
Release 6.100.1: documentation and packaging fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 .idea/
 .DS_Store
 .vscode/settings.json
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -6,5 +6,9 @@ resources
 src
 test
 __tests__
+dist/__tests__
+.env
+.env.*
+ENDPOINT_COVERAGE.md
 .eslintrc.json
 tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+6.100.1 / 2026-08-18
+==========
+
+**Bug Fixes**
+
+* Correct documentation and packaging hygiene ahead of 7.x: publish readme wording, endpoint coverage method names and test scripts, readme API examples, prerequisites URL, missing method docs (`accVerification`, `getPayee`, `getConsentHistory`, `confirmFundsForRecurringPayment`), CHANGELOG 6.99.0 phantom entry, package author typo, and `.npmignore` exclusions for `dist/__tests__` and env files.
+
 6.100.0 / 2026-08-14
 ==========
 
@@ -19,7 +26,6 @@
 **Features**
 
 * Add CaaS custom category methods: `caasGetCustomCategories`, `caasCreateCustomCategory`, `caasDeleteCustomCategory`.
-* Add `postLlmGatewaySavingsGoals` for `POST /llm-gateway/savings-goals` (scope `llm_gateway_savings_goals:write`).
 
 6.98.0 / 2026-06-09
 ==========

--- a/ENDPOINT_COVERAGE.md
+++ b/ENDPOINT_COVERAGE.md
@@ -25,13 +25,13 @@ This document maps API definitions (Swagger and router definitions) to the money
 | Beneficiaries | getBeneficiary, getBeneficiaryWithDetail, getBeneficiaries, getBeneficiariesWithDetail | beneficiaries | |
 | GET /global-counterparties | getGlobalCounterparties | unauthenticated | |
 | Transactions, files, splits | getTransactions, getTransaction, getUnenrichedTransactions, getUnenrichedTransaction, addTransaction, addTransactions, getTransactionFiles, getTransactionFile, addFileToTransaction, deleteTransactionFile, getTransactionSplits, splitTransaction, patchTransactionSplit, deleteTransactionSplits | transactions, transaction-files, transaction-splits | |
-| Categories, category-groups | getCategories, getCategory, getCategoryGroups, getStandardCategories, getStandardCategoryGroups, createCustomCategory, updateCategory, deleteCategory | categories | |
-| Categorise, regular-transactions | categoriseTransactions, getRegularTransactions, addRegularTransaction, updateRegularTransaction, deleteRegularTransaction, detectRegularTransactions | categorise-transactions, regular-transactions | |
+| Categories, category-groups | getCategories, getCategory, getCategoryGroups, getStandardCategories, getStandardCategoryGroups, createCustomCategory | categories | |
+| Categorise, regular-transactions | categoriseTransactions, getRegularTransactions, detectRegularTransactions | categorise-transactions, regular-transactions | |
 | Rental records | (rental-records module) | rental-records | |
-| Spending analysis, spending/savings goals | getSpendingAnalysis, getSpendingGoals, getSpendingGoal, addSpendingGoal, updateSpendingGoal, deleteSpendingGoal, getSavingsGoals, getSavingsGoal, addSavingsGoal, updateSavingsGoal, deleteSavingsGoal | spending-analysis, spending-goals, savings-goals | |
+| Spending analysis, spending/savings goals | getSpendingAnalysis, getSpendingGoals, getSpendingGoal, createSpendingGoal, updateSpendingGoal, deleteSpendingGoal, getSavingsGoals, getSavingsGoal, createSavingsGoal, updateSavingsGoal, deleteSavingsGoal | spending-analysis, spending-goals, savings-goals | |
 | GET /standard-financial-statements, GET /standard-financial-statements/{reportId} | getStandardFinancialStatements, getStandardFinancialStatement | standard-financial-statements | |
 | Sync, projects, tax | syncUserConnection, getProjects, getProject, addProject, updateProject, deleteProject, getTaxReturn | sync, projects, tax | |
-| Notification thresholds | getNotificationThresholds, addNotificationThreshold, getNotificationThreshold, updateNotificationThreshold, deleteNotificationThreshold | notification-thresholds | |
+| Notification thresholds | getNotificationThresholds, addNotificationThreshold, updateNotificationThreshold, deleteNotificationThreshold | notification-thresholds | |
 
 ## 3. Identity – client mapping
 
@@ -47,7 +47,7 @@ This document maps API definitions (Swagger and router definitions) to the money
 | GET .well-known/beta-connections | listBetaConnections | unauthenticated | |
 | GET .well-known/openid-configuration | getOpenIdConfig | unauthenticated | |
 | Auth-requests, OIDC | createAuthRequest, getAuthRequest, getAllAuthRequests, completeAuthRequest, getAuthUrls, token helpers | auth-requests, get-auth-urls, tokens | |
-| Users, connections, syncs, SCIM | getUser, getUsers, registerUser, deleteUser, getUserConnections, deleteUserConnection, updateUserConnection, getConnectionSyncs, getUserSyncs, getSync, getSCIMUser, registerSCIMUser, searchSCIMUsers | users-and-connections | |
+| Users, connections, syncs, SCIM | getUser, getUsers, registerUser, deleteUser, getUserConnections, deleteUserConnection, updateUserConnection, getConnectionSyncs, getUserSyncs, getSync, getSCIMUser, registerSCIMUser | users-and-connections | |
 | Payees, pay-links, payments | addPayee, getPayees, getPayee, getPayment, getPayments, getPaymentFromIDToken, addPayLink, getPayLink, getPayLinks | payees, pay-links, payments | |
 | Standing orders, recurring payments | getStandingOrder, getStandingOrders, getRecurringPayments, getRecurringPayment, makeRecurringPayment, revokeRecurringPayment, confirmFundsForRecurringPayment | standing-orders, recurring-payments | |
 | Reseller-check, consent-history | createResellerCheckRequest, getConsentHistory | reseller-check, consent-history | |
@@ -97,9 +97,9 @@ All require `osip:read` scope. Client fully covers these routes.
 | OSIP | osip.ts |
 | Standard financial statements | standard-financial-statements.ts |
 
-**Running tests and coverage**
+**Running tests**
 
-- **Default config for Moneyhub developers**: see [Moneyhub API Client Integration Tests](https://app.notion.com/p/moneyhub/Moneyhub-API-Client-Integration-Tests-0bef6e3cb922425b88f0268c1a999917) for how to obtain and place the default `config` used by integration (and CaaS) tests.
-- **Unit only** (no API config): `npm run test:coverage` — runs `*.unit.ts`, enforces 90% coverage.
-- **Full suite** (unit + integration, requires config): `npm run test:integration:coverage` — runs all tests with hooks, enforces 90% line/function/branch/statement coverage.
-- Integration tests live in `src/__tests__/*.ts` (non-`.unit.ts`); hooks in `test/hooks.js` provide `this.config` (e.g. `testUserId`, `testAccountId`).
+- **Default config for Moneyhub developers**: see [Moneyhub API Client Tests Config](https://www.notion.so/moneyhub/Moneyhub-API-Client-Tests-Config-0bef6e3cb922425b88f0268c1a999917) for how to obtain and place the default `config` used by integration (and CaaS) tests.
+- **Integration suite** (requires local config): `npm test` or `npm run test-ci`.
+- **CaaS suite** (requires CaaS config): `npm run test-caas` or `npm run test-caas-ci`.
+- Integration tests live in `src/__tests__/**/*.ts`; hooks in `test/hooks.js` provide `this.config` (e.g. `testUserId`, `testAccountId`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mft/moneyhub-api-client",
-  "version": "6.100.0",
+  "version": "6.100.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mft/moneyhub-api-client",
-      "version": "6.100.0",
+      "version": "6.100.1",
       "license": "ISC",
       "dependencies": {
         "@isaacs/ttlcache": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mft/moneyhub-api-client",
-  "version": "6.100.0",
+  "version": "6.100.1",
   "description": "Node.JS client for the Moneyhub API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
     "api",
     "openid"
   ],
-  "author": "Moneyub Financial Technology",
+  "author": "Moneyhub Financial Technology",
   "homepage": "https://github.com/moneyhub/moneyhub-api-client",
   "repository": "moneyhub/moneyhub-api-client",
   "license": "ISC",

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ const {Moneyhub} = require("@mft/moneyhub-api-client")
 
 ## Publishing (maintainers)
 
-Official releases are published to npm by **GitHub Actions** when a [GitHub Release](https://github.com/moneyhub/moneyhub-api-client/releases) is published (see `.github/workflows/publish.yml`). The publish workflow runs lint and build on GitHub-hosted runners; live integration tests run in the private synced repository (allowlisted IPs / secrets). Do not rely on publishing from a developer machine.
+Official releases are published to npm by **GitHub Actions** when a [GitHub Release](https://github.com/moneyhub/moneyhub-api-client/releases) is published (see `.github/workflows/publish.yml`). The publish workflow runs lint and build on GitHub-hosted runners. Live integration tests are not part of publish; they run in the private synced repository (allowlisted IPs / secrets). Do not rely on publishing from a developer machine.
 
 The `prepublishOnly` lifecycle script runs **`scripts/assert-github-actions-publish.js`** before the build. It exits with an error unless `GITHUB_ACTIONS` is set (as it is in GitHub Actions), so a normal local `npm publish` is blocked. That reduces accidental publishes; it is **not** a security boundary on its own—npm access control and trusted publishing still matter.
 
@@ -80,7 +80,7 @@ To use this API client you will need:
 - Node.js >= 18.0.0
 - A `client_id`, `client_secret` and `redirect_uri` of a registered API client
 - The url of the Moneyhub identity service for the environment you are connecting to (https://identity.moneyhub.co.uk)
-- The url for the API gateway for the environment that you are connecting to (https://api.moneyhub.co.uk/v2.0)
+- The url for the API gateway for the environment that you are connecting to (https://api.moneyhub.co.uk/v3)
 
 ## To install
 
@@ -261,6 +261,8 @@ The `expirationDateTime` and `transactionFromDateTime` options can be set accord
 
 Set `enableAsync` to true if you wish to make an AIS connection that won't wait for accounts and transactions to be fetched.
 
+Set `accVerification` to true to add the `mh:account_verification` claim. This is independent of `enableAsync`.
+
 **Note:** all methods generate an authorise URL using the Pushed Authorisation Request (PAR) method, see [here](https://docs.moneyhubenterprise.com/docs/pushed-authorisation-requests-par) for more details.
 
 #### `getAuthorizeUrl`
@@ -284,6 +286,7 @@ const url = await moneyhub.getAuthorizeUrl({
   expirationDateTime: "2022-09-01T00:00:00.000Z", // optional
   transactionFromDateTime: "2020-09-01T00:00:00.000Z", // optional,
   enableAsync: false, // optional
+  accVerification: false, // optional - adds mh:account_verification independently of enableAsync
 });
 
 // Default claims if none are provided
@@ -403,24 +406,6 @@ const defaultClaims = {
 
 #### `getRefreshAuthorizeUrlForCreatedUser`
 
-#### `getAuthorizeUrlLegacy`
-
-This method returns an authorize url for your API client using the legacy method (where a request object is generated and passed in as the `request` query parameter). You can redirect a user to this url, after which they will be redirected back to your `redirect_uri`. It has the same method signature as `getAuthorizeUrl`
-
-```javascript
-const url = await moneyhub.getAuthorizeUrlLegacy({
-  scope: "openid bank-id-scope other-data-scopes",
-  state: " your state value", // optional
-  nonce: "your nonce value", //optional
-  claims: claimsObject, // optional
-  permissions: ["ReadBeneficiariesDetail"], // optional - set of extra permissions to set for auth URL
-  permissionsAction: "replace" // optional - replace default consent permissions. Defaults to "add"
-  expirationDateTime: "2022-09-01T00:00:00.000Z", // optional
-  transactionFromDateTime: "2020-09-01T00:00:00.000Z", // optional,
-  enableAsync: false, // optional
-});
-```
-
 This is a helper function that returns an authorize url for a specific user to refresh an existing connection. This function uses the scope `openid refresh`. (Only relevant for legacy connections)
 
 ```javascript
@@ -446,6 +431,24 @@ const defaultClaims = {
     },
   },
 };
+```
+
+#### `getAuthorizeUrlLegacy`
+
+This method returns an authorize url for your API client using the legacy method (where a request object is generated and passed in as the `request` query parameter). You can redirect a user to this url, after which they will be redirected back to your `redirect_uri`. It has the same method signature as `getAuthorizeUrl`
+
+```javascript
+const url = await moneyhub.getAuthorizeUrlLegacy({
+  scope: "openid bank-id-scope other-data-scopes",
+  state: " your state value", // optional
+  nonce: "your nonce value", //optional
+  claims: claimsObject, // optional
+  permissions: ["ReadBeneficiariesDetail"], // optional - set of extra permissions to set for auth URL
+  permissionsAction: "replace" // optional - replace default consent permissions. Defaults to "add"
+  expirationDateTime: "2022-09-01T00:00:00.000Z", // optional
+  transactionFromDateTime: "2020-09-01T00:00:00.000Z", // optional,
+  enableAsync: false, // optional
+});
 ```
 
 #### `exchangeCodeForTokensLegacy`
@@ -854,7 +857,7 @@ Similar to getAccounts method, however this method does not return `transactionD
 
 ```javascript
 const queryParams = { limit: 10, offset: 5 , showTransacionData: false, showPerformanceScore: true};
-const accounts = await moneyhub.getAccounts({
+const accounts = await moneyhub.getAccountsList({
   userId: "userId",
   params: queryParams,
 }, options);
@@ -866,7 +869,7 @@ Similar to getAccountsWithDetails method, however this method does not return `t
 
 ```javascript
 const queryParams = { limit: 10, offset: 5 };
-const accounts = await moneyhub.getAccountsWithDetails({
+const accounts = await moneyhub.getAccountsListWithDetails({
   userId: "userId",
   params: queryParams,
 }, options);
@@ -1379,11 +1382,9 @@ const accounts = await moneyhub.getOsipAccounts({
 Get an account for a user. This function uses the scope `osip:read`.
 
 ```javascript
-const queryParams = { limit: 10, offset: 5 };
-const accounts = await moneyhub.getOsipAccounts({
+const account = await moneyhub.getOsipAccount({
   userId: "userId",
   accountId: "accountId",
-  params: queryParams,
 });
 ```
 
@@ -1393,7 +1394,7 @@ Get account holdings for an account. This function uses the scope `osip:read`.
 
 ```javascript
 const queryParams = { limit: 10, offset: 5 };
-const accounts = await moneyhub.getOsipAccounts({
+const holdings = await moneyhub.getOsipAccountHoldings({
   userId: "userId",
   accountId: "accountId",
   params: queryParams,
@@ -1406,7 +1407,7 @@ Get account transactions. This function uses the scope `osip:read`.
 
 ```javascript
 const queryParams = { limit: 10, offset: 5 };
-const accounts = await moneyhub.getOsipAccounts({
+const transactions = await moneyhub.getOsipAccountTransactions({
   userId: "userId",
   accountId: "accountId",
   params: queryParams,
@@ -1754,6 +1755,18 @@ const payees = await moneyhub.getPayees({
 });
 ```
 
+#### `getPayee`
+
+Get a single registered payee by id. This function uses the scope `payee:read`.
+
+```javascript
+const payee = await moneyhub.getPayee({
+  id: "payee-id",
+});
+```
+
+Example script: `node examples/payments/get-payee.js -i payee-id`.
+
 #### `getPayments`
 
 This method returns a list of initiated payments. This function uses the scope `payment:read`
@@ -2021,7 +2034,7 @@ const recurringPayment = await moneyhub.getRecurringPayment({
 This method creates a payment using the recurring payment consent. This function uses the scope `recurring_payment:create`
 
 ```javascript
-const recurringPayments = await moneyhub.getRecurringPayments({
+const recurringPayment = await moneyhub.makeRecurringPayment({
   recurringPaymentId: "Id of the recurring payment consent",
   payment: {
     payeeId: "payee-id", // optional
@@ -2041,6 +2054,22 @@ const revokedRecurringPayment = await moneyhub.revokeRecurringPayment({
   recurringPaymentId: "Id of the recurring payment consent",
 });
 ```
+
+#### `confirmFundsForRecurringPayment`
+
+Confirm that funds are available for a payment under an existing recurring payment consent. This function uses the scope `recurring_payment:funds_confirmation`.
+
+```javascript
+const fundsConfirmation = await moneyhub.confirmFundsForRecurringPayment({
+  recurringPaymentId: "Id of the recurring payment consent",
+  fundsConfirmation: {
+    amount: "10.00",
+    currency: "GBP",
+  },
+});
+```
+
+Example script: `node examples/recurring-payments/confirm-funds.js -i recurring-payment-id -a 10.00`.
 
 #### `getRegularTransactions`
 
@@ -2246,6 +2275,20 @@ const resellerCheck = await moneyhub.createResellerCheckRequest({
   email: "email@email.com"
 }, options);
 ```
+
+#### `getConsentHistory`
+
+Get consent history for the API client, optionally filtered by user. This function uses the scope `consent_history:read`.
+
+```javascript
+const consentHistory = await moneyhub.getConsentHistory({
+  limit: 10, // optional
+  offset: 0, // optional
+  userId: "user-id", // optional
+});
+```
+
+Example script: `node examples/consent-history/get-history.js -u user-id`.
 
 ### CAAS API
 


### PR DESCRIPTION
## Summary
Patch release before 7.x with the 12 review items:
1. Clarify publish workflow vs private live tests in readme
2. Rewrite ENDPOINT_COVERAGE running-tests section for current scripts
3. Correct ENDPOINT_COVERAGE method names (goals, categories, SCIM, notifications)
4. Document `accVerification` on `getAuthorizeUrl`
5. Fix readme examples (`getAccountsList*`, OSIP, `makeRecurringPayment`)
6. Prerequisites API URL → `/v3`
7. Add missing sections: `getPayee`, `getConsentHistory`, `confirmFundsForRecurringPayment`
8. Remove phantom `postLlmGatewaySavingsGoals` from CHANGELOG 6.99.0
9. Fix package author typo (Moneyhub)
10. `.npmignore` / `.gitignore` hygiene (`dist/__tests__`, `.env*`, `coverage/`)
11. Fix `getRefreshAuthorizeUrlForCreatedUser` heading structure
12. Align Notion URL; bump version to **6.100.1**

## Test plan
- [x] Spot-check readme sections listed above
- [x] Confirm `package.json` version is `6.100.1`
- [ ] Merge, tag `v6.100.1`, publish GitHub Release to trigger npm publish


Made with [Cursor](https://cursor.com)