### PR TITLE
Update caas tests

### DIFF
--- a/src/__tests__/caas/post-transactions-enrich.ts
+++ b/src/__tests__/caas/post-transactions-enrich.ts
@@ -109,17 +109,17 @@ describe("POST /transactions/enrich", function() {
     })
 
     it("card-present transaction receives geotags", function() {
-      const first = response.data[0]
+      const geoTrx = response.data.find(trx => trx.cardPresent === true)
 
-      expect(first.mhInsights).to.have.property("geotags")
-      expect(first.mhInsights.geotags).to.be.an("array").with.lengthOf(3)
+      expect(geoTrx?.mhInsights).to.have.property("geotags")
+      expect(geoTrx?.mhInsights.geotags).to.be.an("array").with.lengthOf(3)
     })
 
     it("meta is returned intact on enriched transaction", function() {
-      const second = response.data[1]
+      const metaTrx = response.data.find(trx => !!trx.meta)
 
-      expect(second).to.have.property("meta")
-      expect(second.meta).to.deep.equal({hello: "world"})
+      expect(metaTrx).to.have.property("meta")
+      expect(metaTrx?.meta).to.deep.equal({hello: "world"})
     })
   })
 

--- a/src/__tests__/caas/put-transaction-splits.ts
+++ b/src/__tests__/caas/put-transaction-splits.ts
@@ -33,7 +33,7 @@ describe("PUT /accounts/{accountId}/transactions/{transactionId}/splits", functi
       }
 
       const {caas: {accountId}} = this.config
-      const transactionId = this.transactionIds[0]
+      const transactionId = "08820421-8472-4254-8608-f0d59e3b0a99"
 
       requestBody = {
         data: [
@@ -64,7 +64,7 @@ describe("PUT /accounts/{accountId}/transactions/{transactionId}/splits", functi
       }
 
       const {caas: {accountId}} = this.config
-      const transactionId = this.transactionIds[0]
+      const transactionId = "08820421-8472-4254-8608-f0d59e3b0a99"
 
       await moneyhub.caasDeleteTransactionSplits({accountId, transactionId})
     })


### PR DESCRIPTION
Accounts for transactions being received from the enrichment endpoint not necessarily being in the same order they were sent in (environment dependant)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 619e7141fd694619e0e33cdae49d3de592c1f45f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->